### PR TITLE
Add interactive video view

### DIFF
--- a/editor-settings.toml
+++ b/editor-settings.toml
@@ -184,6 +184,17 @@ spanish = { lang = "es" }
 # Default: false
 #simpleMode = false
 
+####
+# Interactive Elements
+##
+
+[interactiveElements]
+
+# If the interactive elements editor appears in the main menu
+# Type: boolean
+# Default: false
+#show = false
+
 
 
 ############################################################

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,12 @@ interface iSettings {
     mainFlavor: string,
     defaultVideoFlavor: Flavor | undefined,
   };
+  interactiveElements: {
+    show: boolean,
+    textboxesMainFlavor: string,
+    quizzesMainFlavor: string,
+    defaultVideoFlavor: Flavor | undefined,
+  };
 }
 
 /**
@@ -124,6 +130,12 @@ const defaultSettings: iSettings = {
   chapters: {
     show: false,
     mainFlavor: "chapters",
+    defaultVideoFlavor: undefined,
+  },
+  interactiveElements: {
+    show: false,
+    textboxesMainFlavor: "textboxes",
+    quizzesMainFlavor: "quizzes",
     defaultVideoFlavor: undefined,
   },
 };
@@ -427,6 +439,12 @@ const SCHEMA = {
   chapters: {
     show: types.boolean,
     mainFlavor: types.string,
+    defaultVideoFlavor: types.map,
+  },
+  interactiveElements: {
+    show: types.boolean,
+    textboxesMainFlavor: types.string,
+    quizzesMainFlavor: types.string,
     defaultVideoFlavor: types.map,
   },
   thumbnail: {

--- a/src/cssStyles.tsx
+++ b/src/cssStyles.tsx
@@ -432,3 +432,15 @@ export const undisplayContainer = (maxWidth: number) => css({
     display: "none",
   },
 });
+
+export const timeInputStyle = (theme: Theme) => css({
+  fontSize: "1em",
+  marginLeft: "15px",
+  marginRight: "2px",
+  borderRadius: "5px",
+  borderWidth: "1px",
+  padding: "10px 10px",
+  background: `${theme.element_bg}`,
+  border: "1px solid #ccc",
+  color: `${theme.text}`,
+});

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -367,8 +367,9 @@
       "quiz": {
         "question": "Question",
         "answers": "Answers",
+        "answer": "Answer",
         "answerCorrect": "Correct",
-        "answerIncorrect": "Incorrect"
+        "answerDelete": "Remove"
       }
     },
 

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -6,6 +6,7 @@
       "subtitles-button": "Subtitles",
       "chapters-button": "Chapters",
       "thumbnail-button": "Thumbnail",
+      "interactiveElements-button": "Interactive Elements",
       "metadata-button": "Metadata",
       "keyboard-controls-button": "Keyboard Controls",
       "tooltip-aria": "Main Navigation"
@@ -334,6 +335,39 @@
 
     "chapters": {
       "editTitle": "Chapter Editor"
+    },
+
+    "interactiveElements" : {
+      "title": "Interactive Elements Editor",
+      "addTextbox": "Add Textbox",
+      "addTextbox-tooltip": "Add a textbox at the current timeline marker position.",
+      "addTextbox-tooltip-aria": "Add. Add a textbox at the current timeline marker position.",
+      "addQuiz": "Add Quiz",
+      "addQuiz-tooltip": "Add a quiz at the current timeline marker position.",
+      "addQuiz-tooltip-aria": "Add. Add a quiz at the current timeline marker position.",
+      "editElement-tooltip": "Edit the current element",
+      "editElement-tooltip-aria": "Edit the current element",
+      "deleteElement-tooltip": "Delete the current element",
+      "deleteElement-tooltip-aria": "Delete the current element"
+    },
+
+    "interactiveElementsEditor": {
+      "title": {
+        "textbox": "Textbox Editor",
+        "quiz": "Quiz Editor"
+      },
+      "start": "Start",
+      "submit": "Submit",
+      "textbox": {
+        "text": "Text",
+        "link": "Link"
+      },
+      "quiz": {
+        "question": "Question",
+        "answers": "Answers",
+        "answerCorrect": "Correct",
+        "answerIncorrect": "Incorrect"
+      }
     },
 
     "keyboardControls": {

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -361,10 +361,12 @@
       "start": "Start",
       "submit": "Submit",
       "textbox": {
+        "description": "A little box for displaying a small amount of text and optionally a link. The box remains on screen for ten seconds.",
         "text": "Text",
         "link": "Link"
       },
       "quiz": {
+        "description": "Stops the video at the start time to display a multiple-choice quiz.",
         "question": "Question",
         "answers": "Answers",
         "answer": "Answer",

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -348,7 +348,9 @@
       "editElement-tooltip": "Edit the current element",
       "editElement-tooltip-aria": "Edit the current element",
       "deleteElement-tooltip": "Delete the current element",
-      "deleteElement-tooltip-aria": "Delete the current element"
+      "deleteElement-tooltip-aria": "Delete the current element",
+      "deleteElement-warning-header": "Caution!",
+      "deleteElement-warning": "This will remove the element! Are you sure?"
     },
 
     "interactiveElementsEditor": {

--- a/src/main/CuttingActions.tsx
+++ b/src/main/CuttingActions.tsx
@@ -310,7 +310,7 @@ interface cuttingActionsButtonInterface {
  * A button representing a single action a user can take while cutting
  * @param param0
  */
-const CuttingActionsButton: React.FC<cuttingActionsButtonInterface> = ({
+export const CuttingActionsButton: React.FC<cuttingActionsButtonInterface> = ({
   Icon,
   actionName,
   actionHandler,
@@ -393,7 +393,7 @@ interface ZoomSliderInterface {
   ariaLabelText: string,
 }
 
-const ZoomSlider : React.FC<ZoomSliderInterface> = ({
+export const ZoomSlider : React.FC<ZoomSliderInterface> = ({
   actionHandler,
   tooltip,
   ariaLabelText,

--- a/src/main/CuttingActionsContextMenu.tsx
+++ b/src/main/CuttingActionsContextMenu.tsx
@@ -12,8 +12,12 @@ import { selectKeymap } from "../redux/hotkeySlice";
 
 const CuttingActionsContextMenu: React.FC<{
   children: React.ReactNode,
+  isChapters?: boolean
+  isInteractiveElements?: boolean,
 }> = ({
   children,
+  isChapters = false,
+  isInteractiveElements = false,
 }) => {
 
   const { t } = useTranslation();
@@ -62,12 +66,34 @@ const CuttingActionsContextMenu: React.FC<{
     },
   ];
 
+  const render = () => {
+    if (isChapters) {
+      return (
+        <>
+          {children}
+        </>
+      );
+    }
+    if (isInteractiveElements) {
+      return (
+        <>
+          {children}
+        </>
+      );
+    }
+    return (
+      <ThemedContextMenu
+        menuItems={cuttingContextMenuItems}
+      >
+        {children}
+      </ThemedContextMenu>
+    );
+  };
+
   return (
-    <ThemedContextMenu
-      menuItems={cuttingContextMenuItems}
-    >
-      {children}
-    </ThemedContextMenu>
+    <>
+      {render()}
+    </>
   );
 };
 

--- a/src/main/InteractiveElementEditor.tsx
+++ b/src/main/InteractiveElementEditor.tsx
@@ -105,6 +105,11 @@ const TextboxEditor: React.FC<{
   const modalStyle = css({
     display: "flex",
     flexDirection: "column",
+    gap: "10px",
+  });
+
+  const descriptionStyle = css({
+    maxWidth: "400px",
   });
 
   const fieldsStyle = css({
@@ -117,6 +122,9 @@ const TextboxEditor: React.FC<{
 
   return (
     <div css={modalStyle}>
+      <div css={descriptionStyle}>
+        {t("interactiveElementsEditor.textbox.description")}
+      </div>
       <div css={fieldsStyle}>
         <label>{t("interactiveElementsEditor.start")}</label>
         <TimeInput
@@ -232,6 +240,11 @@ const QuizEditor: React.FC<{
   const modalStyle = css({
     display: "flex",
     flexDirection: "column",
+    gap: "10px",
+  });
+
+  const descriptionStyle = css({
+    maxWidth: "480px",
   });
 
   const fieldsStyle = css({
@@ -263,6 +276,9 @@ const QuizEditor: React.FC<{
 
   return (
     <div css={modalStyle}>
+      <div css={descriptionStyle}>
+        {t("interactiveElementsEditor.quiz.description")}
+      </div>
       <div css={fieldsStyle}>
         <label>{t("interactiveElementsEditor.start")}</label>
         <TimeInput

--- a/src/main/InteractiveElementEditor.tsx
+++ b/src/main/InteractiveElementEditor.tsx
@@ -243,7 +243,8 @@ const QuizEditor: React.FC<{
   });
 
   const segmentButtonStyle = css({
-    height: "32px",
+    height: "100%",
+    width: "44px",
     boxShadow: `${theme.boxShadow}`,
     background: `${theme.element_bg}`,
   });
@@ -279,6 +280,11 @@ const QuizEditor: React.FC<{
         />
         <label>{t("interactiveElementsEditor.quiz.answers")}</label>
         <div css={answersStyle}>
+          <div css={answerStyle}>
+            <div css={{ paddingLeft: "15px" }}>{t("interactiveElementsEditor.quiz.answer")}</div>
+            <div>{t("interactiveElementsEditor.quiz.answerCorrect")}</div>
+            <div>{t("interactiveElementsEditor.quiz.answerDelete")}</div>
+          </div>
           { quiz.answers.map((answer, i) => {
             return (
               <div key={i} css={answerStyle}>
@@ -287,14 +293,12 @@ const QuizEditor: React.FC<{
                   value={answer.text}
                   onChange={e => updateAnswerText(i, e.target.value)}
                 />
-                <ProtoButton
-                  css={[basicButtonStyle(theme), segmentButtonStyle]}
-                  onClick={() => updateAnswerCorrect(i, !answer.correct)}
-                >
-                  {answer.correct
-                    ? t("interactiveElementsEditor.quiz.answerCorrect")
-                    : t("interactiveElementsEditor.quiz.answerIncorrect")}
-                </ProtoButton>
+                <input
+                  type={"checkbox"}
+                  css={basicButtonStyle(theme)}
+                  checked={answer.correct}
+                  onChange={e => updateAnswerCorrect(i, e.target.checked)}
+                />
                 <ProtoButton
                   css={[basicButtonStyle(theme), segmentButtonStyle]}
                   onClick={() => removeAnswer(i)}

--- a/src/main/InteractiveElementEditor.tsx
+++ b/src/main/InteractiveElementEditor.tsx
@@ -1,0 +1,317 @@
+import { useTranslation } from "react-i18next";
+import { useAppDispatch } from "../redux/store";
+import { TimeInput } from "./SubtitleListEditor";
+import { useState } from "react";
+import { css } from "@emotion/react";
+import { useTheme } from "../themes";
+import { timeInputStyle } from "../cssStyles";
+import { convertMsToReadableString } from "../util/utilityFunctions";
+import {
+  addInteractiveElement,
+  InteractiveElement,
+  Quiz,
+  Textbox,
+} from "../redux/interactiveElementsSlice";
+import { Modal, ModalHandle, ProtoButton } from "@opencast/appkit";
+import { nanoid } from "@reduxjs/toolkit";
+import { LuPlus, LuTrash } from "react-icons/lu";
+import { basicButtonStyle } from "../cssStyles";
+
+/**
+ * Displays an editor view for a selected interactive element
+ */
+const InteractiveElementsEditor: React.FC<{
+  element: Partial<InteractiveElement>
+  modalRef: React.RefObject<ModalHandle | null>
+}> = ({
+  element,
+  modalRef,
+}) => {
+  const { t } = useTranslation();
+
+  const title = element.type === "Quiz"
+    ? t("interactiveElementsEditor.title.quiz")
+    : t("interactiveElementsEditor.title.textbox");
+
+  return (
+    <Modal
+      title={title}
+      text={{ close: "" }}
+      // @ts-expect-error: This is fine and should be fixed in newer appkit versions.
+      ref={modalRef}
+    >
+      { element.type === "Textbox" &&
+        <TextboxEditor
+          element={element}
+          modalRef={modalRef}
+        />
+      }
+      { element.type === "Quiz" &&
+        <QuizEditor
+          element={element}
+          modalRef={modalRef}
+        />
+      }
+    </Modal>
+  );
+};
+
+const TextboxEditor: React.FC<{
+  element: Partial<Textbox>,
+  modalRef: React.RefObject<ModalHandle | null>,
+}> = ({
+  element,
+  modalRef,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const dispatch = useAppDispatch();
+
+  const [textbox, setTextbox] = useState<Textbox>({
+    idInternal: nanoid(),
+    start: 0,
+    text: "",
+    type: "Textbox",
+    ...element,
+  });
+
+
+  const updateStartTime = (value: number) => {
+    setTextbox({
+      ...textbox,
+      start: value,
+    });
+  };
+
+  const updateText = (value: string) => {
+    setTextbox({
+      ...textbox,
+      text: value,
+    });
+  };
+
+  const submit = () => {
+    dispatch(addInteractiveElement(textbox));
+    modalRef.current?.close?.();
+  };
+
+  const modalStyle = css({
+    display: "flex",
+    flexDirection: "column",
+  });
+
+  const fieldsStyle = css({
+    display: "grid",
+    gridTemplateColumns: "1fr 4fr",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: "10px",
+  });
+
+  return (
+    <div css={modalStyle}>
+      <div css={fieldsStyle}>
+        <label>{t("interactiveElementsEditor.start")}</label>
+        <TimeInput
+          generalFieldStyle={[timeInputStyle(theme)]}
+          value={textbox.start}
+          changeCallback={updateStartTime}
+          tooltip={t("subtitleList.startTime-tooltip")}
+          tooltipAria={t("subtitleList.startTime-tooltip-aria") + ": " + convertMsToReadableString(textbox.start)}
+        />
+        <label>{t("interactiveElementsEditor.textbox.text")}</label>
+        <input
+          css={timeInputStyle(theme)}
+          value={textbox.text}
+          onChange={e => updateText(e.target.value)}
+        />
+        <label>{t("interactiveElementsEditor.textbox.link")}</label>
+        <input
+          css={timeInputStyle(theme)}
+          value={textbox.link}
+          onChange={e => updateText(e.target.value)}
+        />
+      </div>
+      <ProtoButton
+        css={[basicButtonStyle(theme), { marginTop: "10px", padding: "10px 0px" }]}
+        onClick={submit}
+      >
+        {t("interactiveElementsEditor.submit")}
+      </ProtoButton>
+    </div>
+  );
+};
+
+const QuizEditor: React.FC<{
+  element: Partial<Quiz>,
+  modalRef: React.RefObject<ModalHandle | null>
+}> = ({
+  element,
+  modalRef,
+}) => {
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const dispatch = useAppDispatch();
+
+  const [quiz, setQuiz] = useState<Quiz>({
+    idInternal: nanoid(),
+    start: 0,
+    question: "",
+    answers: [],
+    type: "Quiz",
+    ...element,
+  });
+
+  const updateStartTime = (value: number) => {
+    setQuiz({
+      ...quiz,
+      start: value,
+    });
+  };
+
+  const updateQuestion = (value: string) => {
+    setQuiz({
+      ...quiz,
+      question: value,
+    });
+  };
+
+  const updateAnswerText = (index: number, value: string) => {
+    setQuiz({
+      ...quiz,
+      answers: quiz.answers.map((a, i) =>
+        i === index ? { ...a, text: value } : a,
+      ),
+    });
+  };
+
+  const updateAnswerCorrect = (index: number, value: boolean) => {
+    setQuiz({
+      ...quiz,
+      answers: quiz.answers.map((a, i) =>
+        i === index ? { ...a, correct: value } : a,
+      ),
+    });
+  };
+
+  const removeAnswer = (index: number) => {
+    setQuiz({
+      ...quiz,
+      answers: quiz.answers.filter((_, i) => i !== index),
+    });
+  };
+
+  const newAnswer = () => {
+    setQuiz({
+      ...quiz,
+      answers: [
+        ...quiz.answers,
+        {
+          text: "",
+          correct: false,
+        },
+      ],
+    });
+  };
+
+  const submit = () => {
+    dispatch(addInteractiveElement(quiz));
+    modalRef.current?.close?.();
+  };
+
+  const modalStyle = css({
+    display: "flex",
+    flexDirection: "column",
+  });
+
+  const fieldsStyle = css({
+    display: "grid",
+    gridTemplateColumns: "1fr 4fr",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: "10px",
+  });
+
+  const segmentButtonStyle = css({
+    height: "32px",
+    boxShadow: `${theme.boxShadow}`,
+    background: `${theme.element_bg}`,
+  });
+
+  const answersStyle = css({
+    display: "flex",
+    flexDirection: "column",
+    gap: "10px",
+  });
+
+  const answerStyle = css({
+    display: "grid",
+    gridTemplateColumns: "4fr 1fr 1fr",
+    gap: "10px",
+  });
+
+  return (
+    <div css={modalStyle}>
+      <div css={fieldsStyle}>
+        <label>{t("interactiveElementsEditor.start")}</label>
+        <TimeInput
+          generalFieldStyle={[timeInputStyle(theme)]}
+          value={quiz.start}
+          changeCallback={updateStartTime}
+          tooltip={t("subtitleList.startTime-tooltip")}
+          tooltipAria={t("subtitleList.startTime-tooltip-aria") + ": " + convertMsToReadableString(quiz.start)}
+        />
+        <label>{t("interactiveElementsEditor.quiz.question")}</label>
+        <input
+          css={[timeInputStyle(theme)]}
+          value={quiz.question}
+          onChange={e => updateQuestion(e.target.value)}
+        />
+        <label>{t("interactiveElementsEditor.quiz.answers")}</label>
+        <div css={answersStyle}>
+          { quiz.answers.map((answer, i) => {
+            return (
+              <div key={i} css={answerStyle}>
+                <input
+                  css={[timeInputStyle(theme)]}
+                  value={answer.text}
+                  onChange={e => updateAnswerText(i, e.target.value)}
+                />
+                <ProtoButton
+                  css={[basicButtonStyle(theme), segmentButtonStyle]}
+                  onClick={() => updateAnswerCorrect(i, !answer.correct)}
+                >
+                  {answer.correct
+                    ? t("interactiveElementsEditor.quiz.answerCorrect")
+                    : t("interactiveElementsEditor.quiz.answerIncorrect")}
+                </ProtoButton>
+                <ProtoButton
+                  css={[basicButtonStyle(theme), segmentButtonStyle]}
+                  onClick={() => removeAnswer(i)}
+                >
+                  <LuTrash />
+                </ProtoButton>
+              </div>
+            );
+          })}
+          <ProtoButton
+            css={[basicButtonStyle(theme)]}
+            onClick={() => newAnswer()}
+          >
+            <LuPlus />
+          </ProtoButton>
+        </div>
+      </div>
+      <ProtoButton
+        css={[basicButtonStyle(theme), { marginTop: "10px", padding: "10px 0px" }]}
+        onClick={() => submit()}
+      >
+        {t("interactiveElementsEditor.submit")}
+      </ProtoButton>
+    </div>
+  );
+};
+
+
+
+export default InteractiveElementsEditor;

--- a/src/main/InteractiveElementEditor.tsx
+++ b/src/main/InteractiveElementEditor.tsx
@@ -90,6 +90,13 @@ const TextboxEditor: React.FC<{
     });
   };
 
+  const updateLink = (value: string) => {
+    setTextbox({
+      ...textbox,
+      link: value,
+    });
+  };
+
   const submit = () => {
     dispatch(addInteractiveElement(textbox));
     modalRef.current?.close?.();
@@ -129,7 +136,7 @@ const TextboxEditor: React.FC<{
         <input
           css={timeInputStyle(theme)}
           value={textbox.link}
-          onChange={e => updateText(e.target.value)}
+          onChange={e => updateLink(e.target.value)}
         />
       </div>
       <ProtoButton

--- a/src/main/InteractiveElementEditor.tsx
+++ b/src/main/InteractiveElementEditor.tsx
@@ -164,7 +164,10 @@ const QuizEditor: React.FC<{
     idInternal: nanoid(),
     start: 0,
     question: "",
-    answers: [],
+    answers: [
+      { text: "", correct: true },
+      { text: "", correct: true },
+    ],
     type: "Quiz",
     ...element,
   });

--- a/src/main/InteractiveElements.tsx
+++ b/src/main/InteractiveElements.tsx
@@ -1,0 +1,161 @@
+import { useTranslation } from "react-i18next";
+import { useAppDispatch, useAppSelector } from "../redux/store";
+import { useEffect } from "react";
+import SubtitleVideoArea from "./SubtitleVideoArea";
+import Timeline from "./Timeline";
+import { css } from "@emotion/react";
+import { useTheme } from "../themes";
+import { titleStyle, titleStyleBold } from "../cssStyles";
+import {
+  dummy,
+  selectAspectRatio,
+  selectClickTriggered,
+  selectCurrentlyAt,
+  selectCurrentlyAtInSeconds,
+  selectIsPlaying,
+  selectIsPlayPreview,
+  selectPreviewTriggered,
+  selectQuizzesFromOpencast,
+  selectTextBoxesFromOpencast,
+  setAspectRatio,
+  setClickTriggered,
+  setCurrentlyAt,
+  setIsPlaying,
+  setIsPlayPreview,
+  setPreviewTriggered,
+} from "../redux/videoSlice";
+import InteractiveElementsList from "./InteractiveElementsList";
+import {
+  InteractiveElement,
+  Quiz,
+  selectInteractiveElements,
+  setInteractiveElements,
+  Textbox,
+} from "../redux/interactiveElementsSlice";
+import InteractiveElementsActions from "./InteractiveElementsActions";
+import { nanoid } from "@reduxjs/toolkit";
+
+/**
+ * Displays an editor view for a selected subtitle file
+ */
+const InteractiveElements: React.FC = () => {
+  const { t } = useTranslation();
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+
+  const textboxTrack = useAppSelector(state => selectTextBoxesFromOpencast(state));
+  const quizTrack = useAppSelector(state => selectQuizzesFromOpencast(state));
+  const interactiveElements = useAppSelector(state => selectInteractiveElements(state));
+
+  // Prepare subtitle in redux
+  useEffect(() => {
+    // Parse subtitle data from Opencast
+    if (interactiveElements.length === 0) {
+      const parsedElements: InteractiveElement[] = [];
+      if (textboxTrack) {
+        const textboxes: Textbox[] = JSON.parse(textboxTrack.elementsJSON);
+        for (const textbox of textboxes) {
+          parsedElements.push({
+            ...textbox,
+            type: "Textbox",
+            idInternal: nanoid(),
+          });
+        }
+      }
+      if (quizTrack) {
+        const quizzes: Quiz[] = JSON.parse(quizTrack.elementsJSON);
+        for (const quiz of quizzes) {
+          parsedElements.push({
+            ...quiz,
+            type: "Quiz",
+            idInternal: nanoid(),
+          });
+        }
+      }
+      parsedElements.sort((a, b) => a.start - b.start);
+
+      dispatch(setInteractiveElements(parsedElements));
+    }
+  }, [dispatch, interactiveElements.length, textboxTrack, quizTrack]);
+
+  const subtitleEditorStyle = css({
+    display: "flex",
+    flexDirection: "column",
+    paddingRight: "20px",
+    paddingLeft: "20px",
+    gap: "20px",
+    height: "100%",
+  });
+
+  const headerRowStyle = css({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    width: "100%",
+    gap: "10px",
+    padding: "15px",
+  });
+
+  const subAreaStyle = css({
+    display: "flex",
+    flexDirection: "row",
+    flexGrow: 1,  // No fixed height, fill available space
+    justifyContent: "space-between",
+    alignItems: "top",
+    width: "100%",
+    paddingTop: "10px",
+    paddingBottom: "10px",
+    gap: "30px",
+    borderBottom: `${theme.menuBorder}`,
+  });
+
+  const render = () => {
+    return (
+      <>
+        <div css={headerRowStyle}>
+          <div css={[titleStyle(theme), titleStyleBold(theme), { padding: "0px" }]}>
+            {t("interactiveElements.title")}
+          </div>
+        </div>
+        <div css={subAreaStyle}>
+          <InteractiveElementsList
+          />
+          <SubtitleVideoArea
+            selectIsPlaying={selectIsPlaying}
+            selectCurrentlyAt={selectCurrentlyAt}
+            selectCurrentlyAtInSeconds={selectCurrentlyAtInSeconds}
+            selectClickTriggered={selectClickTriggered}
+            selectPreviewTriggered={selectPreviewTriggered}
+            selectAspectRatio={selectAspectRatio}
+            selectIsPlayPreview={selectIsPlayPreview}
+            selectSelectedSubtitleById={dummy}
+            setIsPlaying={setIsPlaying}
+            setPreviewTriggered={setPreviewTriggered}
+            setAspectRatio={setAspectRatio}
+            setIsPlayPreview={setIsPlayPreview}
+            setClickTriggered={setClickTriggered}
+            setCurrentlyAtAndTriggerPreview={setCurrentlyAt}
+          />
+        </div>
+        <Timeline
+          selectCurrentlyAt={selectCurrentlyAt}
+          selectIsPlaying={selectIsPlaying}
+          setClickTriggered={setClickTriggered}
+          setCurrentlyAt={setCurrentlyAt}
+          setIsPlaying={setIsPlaying}
+          isInteractiveElements={true}
+        />
+        <InteractiveElementsActions />
+      </>
+    );
+  };
+
+  return (
+    <div css={subtitleEditorStyle}>
+      {render()}
+    </div>
+  );
+};
+
+export default InteractiveElements;

--- a/src/main/InteractiveElements.tsx
+++ b/src/main/InteractiveElements.tsx
@@ -53,7 +53,7 @@ const InteractiveElements: React.FC = () => {
     if (interactiveElements.length === 0) {
       const parsedElements: InteractiveElement[] = [];
       if (textboxTrack) {
-        const textboxes: Textbox[] = JSON.parse(textboxTrack.elementsJSON);
+        const textboxes: Textbox[] = JSON.parse(textboxTrack.elementsJSON) as Textbox[];
         for (const textbox of textboxes) {
           parsedElements.push({
             ...textbox,
@@ -63,7 +63,7 @@ const InteractiveElements: React.FC = () => {
         }
       }
       if (quizTrack) {
-        const quizzes: Quiz[] = JSON.parse(quizTrack.elementsJSON);
+        const quizzes: Quiz[] = JSON.parse(quizTrack.elementsJSON) as Quiz[];
         for (const quiz of quizzes) {
           parsedElements.push({
             ...quiz,
@@ -138,14 +138,16 @@ const InteractiveElements: React.FC = () => {
             setCurrentlyAtAndTriggerPreview={setCurrentlyAt}
           />
         </div>
-        <Timeline
-          selectCurrentlyAt={selectCurrentlyAt}
-          selectIsPlaying={selectIsPlaying}
-          setClickTriggered={setClickTriggered}
-          setCurrentlyAt={setCurrentlyAt}
-          setIsPlaying={setIsPlaying}
-          isInteractiveElements={true}
-        />
+        <div>
+          <Timeline
+            selectCurrentlyAt={selectCurrentlyAt}
+            selectIsPlaying={selectIsPlaying}
+            setClickTriggered={setClickTriggered}
+            setCurrentlyAt={setCurrentlyAt}
+            setIsPlaying={setIsPlaying}
+            isInteractiveElements={true}
+          />
+        </div>
         <InteractiveElementsActions />
       </>
     );

--- a/src/main/InteractiveElementsActions.tsx
+++ b/src/main/InteractiveElementsActions.tsx
@@ -10,8 +10,8 @@ import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
   selectCurrentlyAt,
 } from "../redux/videoSlice";
-import { KEYMAP, rewriteKeys } from "../globalKeys";
-import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/toolkit";
+import { rewriteKeys } from "../globalKeys";
+import { ActionCreatorWithoutPayload, PayloadActionCreator } from "@reduxjs/toolkit";
 
 import { useTranslation } from "react-i18next";
 import { useTheme } from "../themes";
@@ -20,6 +20,7 @@ import { ModalHandle, ProtoButton } from "@opencast/appkit";
 import { ZoomSlider } from "./CuttingActions";
 import InteractiveElementsEditor from "./InteractiveElementEditor";
 import { InteractiveElement } from "../redux/interactiveElementsSlice";
+import { selectKeymap } from "../redux/hotkeySlice";
 
 /**
  * Defines the different actions a user can perform while in cutting mode
@@ -31,6 +32,7 @@ const InteractiveElementsActions: React.FC = () => {
   // Init redux variables
   const dispatch = useAppDispatch();
   const theme = useTheme();
+  const keymap = useAppSelector(selectKeymap);
 
   const modalRef = useRef<ModalHandle>(null);
   const [type, setType] = useState<InteractiveElement["type"]>("Textbox");
@@ -43,11 +45,10 @@ const InteractiveElementsActions: React.FC = () => {
    * @param action redux event to dispatch
    * @param ref Pass a reference if the clicked element should lose focus
    */
-  const dispatchAction = (
+  const dispatchAction = <T, >(
     action: ActionCreatorWithoutPayload<string> | undefined,
-    actionWithPayload?: ActionCreatorWithPayload<number, string>,
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    payload?: any,
+    actionWithPayload?: PayloadActionCreator<T, string>,
+    payload?: T,
     ref?: React.RefObject<HTMLButtonElement>,
   ) => {
     if (action) {
@@ -119,12 +120,12 @@ const InteractiveElementsActions: React.FC = () => {
       <div css={verticalLineStyle} />
       <ZoomSlider actionHandler={dispatchAction}
         tooltip={t("cuttingActions.zoomSlider-tooltip", {
-          hotkeyNameIn: rewriteKeys(KEYMAP.cutting.zoomIn),
-          hotkeyNameOut: rewriteKeys(KEYMAP.cutting.zoomOut),
+          hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn),
+          hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut),
         })}
         ariaLabelText={t("cuttingActions.zoomSlider-aria", {
-          hotkeyNameIn: rewriteKeys(KEYMAP.cutting.zoomIn),
-          hotkeyNameOut: rewriteKeys(KEYMAP.cutting.zoomOut),
+          hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn),
+          hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut),
         })}
       />
     </div>

--- a/src/main/InteractiveElementsActions.tsx
+++ b/src/main/InteractiveElementsActions.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from "react";
 
 import { BREAKPOINTS, basicButtonStyle, undisplay } from "../cssStyles";
 
-import { LuFileQuestion, LuSquareSigma } from "react-icons/lu";
+import { LuFileQuestion, LuType } from "react-icons/lu";
 
 import { css } from "@emotion/react";
 
@@ -98,7 +98,7 @@ const InteractiveElementsActions: React.FC = () => {
           }}
           css={[basicButtonStyle(theme), cuttingActionButtonStyle]}
         >
-          <LuSquareSigma />
+          <LuType />
           <span css={undisplay(BREAKPOINTS.medium)}>{t("interactiveElements.addTextbox")}</span>
         </ProtoButton>
       </ThemedTooltip>

--- a/src/main/InteractiveElementsActions.tsx
+++ b/src/main/InteractiveElementsActions.tsx
@@ -1,0 +1,134 @@
+import React, { useRef, useState } from "react";
+
+import { BREAKPOINTS, basicButtonStyle, undisplay } from "../cssStyles";
+
+import { LuFileQuestion, LuSquareSigma } from "react-icons/lu";
+
+import { css } from "@emotion/react";
+
+import { useAppDispatch, useAppSelector } from "../redux/store";
+import {
+  selectCurrentlyAt,
+} from "../redux/videoSlice";
+import { KEYMAP, rewriteKeys } from "../globalKeys";
+import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/toolkit";
+
+import { useTranslation } from "react-i18next";
+import { useTheme } from "../themes";
+import { ThemedTooltip } from "./Tooltip";
+import { ModalHandle, ProtoButton } from "@opencast/appkit";
+import { ZoomSlider } from "./CuttingActions";
+import InteractiveElementsEditor from "./InteractiveElementEditor";
+import { InteractiveElement } from "../redux/interactiveElementsSlice";
+
+/**
+ * Defines the different actions a user can perform while in cutting mode
+ */
+const InteractiveElementsActions: React.FC = () => {
+
+  const { t } = useTranslation();
+
+  // Init redux variables
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+
+  const modalRef = useRef<ModalHandle>(null);
+  const [type, setType] = useState<InteractiveElement["type"]>("Textbox");
+
+  const currentlyAt = useAppSelector(selectCurrentlyAt);
+
+  /**
+   * General action callback for cutting actions
+   * @param event event triggered by click or button press
+   * @param action redux event to dispatch
+   * @param ref Pass a reference if the clicked element should lose focus
+   */
+  const dispatchAction = (
+    action: ActionCreatorWithoutPayload<string> | undefined,
+    actionWithPayload?: ActionCreatorWithPayload<number, string>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    payload?: any,
+    ref?: React.RefObject<HTMLButtonElement>,
+  ) => {
+    if (action) {
+      dispatch(action());
+    }
+    if (actionWithPayload) {
+      dispatch(actionWithPayload(payload));
+    }
+
+    // Lose focus if clicked by mouse
+    if (ref) {
+      ref.current?.blur();
+    }
+  };
+
+  const cuttingStyle = css({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    flexWrap: "wrap",
+  });
+
+  const cuttingActionButtonStyle = css({
+    padding: "16px",
+  });
+
+  const verticalLineStyle = css({
+    borderLeft: "2px solid #DDD;",
+    height: "32px",
+  });
+
+  return (
+    <div css={cuttingStyle}>
+      <InteractiveElementsEditor
+        element={{
+          start: currentlyAt,
+          type: type,
+        }}
+        modalRef={modalRef}
+      />
+      <ThemedTooltip title={t("interactiveElements.addTextbox-tooltip")}>
+        <ProtoButton
+          aria-label={t("interactiveElements.addTextbox-tooltip-aria")}
+          onClick={() => {
+            setType("Textbox");
+            modalRef.current?.open();
+          }}
+          css={[basicButtonStyle(theme), cuttingActionButtonStyle]}
+        >
+          <LuSquareSigma />
+          <span css={undisplay(BREAKPOINTS.medium)}>{t("interactiveElements.addTextbox")}</span>
+        </ProtoButton>
+      </ThemedTooltip>
+      <div css={verticalLineStyle} />
+      <ThemedTooltip title={t("interactiveElements.addQuiz-tooltip")}>
+        <ProtoButton
+          aria-label={t("interactiveElements.addQuiz-tooltip-aria")}
+          onClick={() => {
+            setType("Quiz");
+            modalRef.current?.open();
+          }}
+          css={[basicButtonStyle(theme), cuttingActionButtonStyle]}
+        >
+          <LuFileQuestion />
+          <span css={undisplay(BREAKPOINTS.medium)}>{t("interactiveElements.addQuiz")}</span>
+        </ProtoButton>
+      </ThemedTooltip>
+      <div css={verticalLineStyle} />
+      <ZoomSlider actionHandler={dispatchAction}
+        tooltip={t("cuttingActions.zoomSlider-tooltip", {
+          hotkeyNameIn: rewriteKeys(KEYMAP.cutting.zoomIn),
+          hotkeyNameOut: rewriteKeys(KEYMAP.cutting.zoomOut),
+        })}
+        ariaLabelText={t("cuttingActions.zoomSlider-aria", {
+          hotkeyNameIn: rewriteKeys(KEYMAP.cutting.zoomIn),
+          hotkeyNameOut: rewriteKeys(KEYMAP.cutting.zoomOut),
+        })}
+      />
+    </div>
+  );
+};
+
+export default InteractiveElementsActions;

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -9,7 +9,7 @@ import { useTranslation } from "react-i18next";
 import { ConfirmationModal, ConfirmationModalHandle, ModalHandle, ProtoButton, useColorScheme } from "@opencast/appkit";
 import { useTheme } from "../themes";
 import { convertMsToReadableString } from "../util/utilityFunctions";
-import { LuFileQuestion, LuPen, LuSquareSigma, LuTrash } from "react-icons/lu";
+import { LuFileQuestion, LuPen, LuType, LuTrash } from "react-icons/lu";
 import { ThemedTooltip } from "./Tooltip";
 import { basicButtonStyle, timeInputStyle } from "../cssStyles";
 import {
@@ -210,7 +210,7 @@ const ListItem: React.FC<{
       zIndex: "1000",
     }]}>
       <div css={typeStyle}>
-        {item.type === "Textbox" ? <LuSquareSigma /> : undefined}
+        {item.type === "Textbox" ? <LuType /> : undefined}
         {item.type === "Quiz" ? <LuFileQuestion /> : undefined}
       </div>
       <TimeInput

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -19,6 +19,7 @@ import {
   updateStartAtIndex,
 } from "../redux/interactiveElementsSlice";
 import InteractiveElementsEditor from "./InteractiveElementEditor";
+import { selectSegments } from "../redux/videoSlice";
 
 /**
  * Displays an overview of interactive elements and assorted actions
@@ -126,6 +127,15 @@ const ListItem: React.FC<{
 
   const modalRef = useRef<ModalHandle>(null);
 
+  const segments = useAppSelector(selectSegments);
+  let wouldBeDeleted = false;
+
+  for (const segment of segments) {
+    if (segment.start < item.start && segment.end > item.start) {
+      wouldBeDeleted = segment.deleted;
+    }
+  }
+
   const updateStartTime = (value: number) => {
     dispatch(updateStartAtIndex({
       index: props.index,
@@ -159,7 +169,7 @@ const ListItem: React.FC<{
   const typeStyle = css({
     width: "32px",
     height: "32px",
-    background: `${theme.element_bg}`,
+    background: wouldBeDeleted ? "rgba(200, 0, 0, 1)" : `${theme.element_bg}`,
     border: "1px solid #ccc",
     zIndex: "1000",
     display: "flex",

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -189,7 +189,6 @@ const ListItem: React.FC<{
   const textFieldStyle = css({
     flexGrow: "7",
     minWidth: "100px",
-    maxWidth: "200px",
     height: "32px",
     background: `${theme.element_bg}`,
     border: "1px solid #ccc",
@@ -238,7 +237,7 @@ const ListItem: React.FC<{
         <ProtoButton
           aria-label={t("interactiveElements.deleteElement-tooltip-aria")}
           onClick={() => deleteModalRef.current?.open()}
-          css={[basicButtonStyle(theme), segmentButtonStyle]}
+          css={[basicButtonStyle(theme), segmentButtonStyle, { marginRight: "2px" }]}
         >
           <LuTrash />
         </ProtoButton>

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -54,6 +54,7 @@ const InteractiveElementsList: React.FC<{
     ({ index, data, style }: ListChildComponentProps<ItemData>) => (
       <ListItem
         index={index}
+        // @ts-expect-error: Type is not properly inferred for some reason
         data={data}
         style={style}
       />
@@ -70,6 +71,8 @@ const InteractiveElementsList: React.FC<{
             itemCount={elements.length}
             itemData={itemData}
             itemSize={_index => segmentHeight}
+            // @ts-expect-error: Type is not properly inferred for some reason
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
             itemKey={(index, data) => data.items[index].idInternal}
             width={width ? width : 0}
             overscanCount={4}
@@ -89,9 +92,13 @@ const InteractiveElementsList: React.FC<{
 /**
  * Helper function for reducing rerender calls caused by react-window
  */
-const createItemData = memoize(items => ({
-  items,
-}));
+function ItemData<T>(
+  items: T,
+) {
+  return { items };
+}
+
+export const createItemData = memoize(ItemData);
 
 /**
  * Global variable to synchronize padding for react-window elements

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -1,0 +1,254 @@
+import React, { CSSProperties, useRef } from "react";
+import AutoSizer from "react-virtualized-auto-sizer";
+import { useAppDispatch, useAppSelector } from "../redux/store";
+import { ListChildComponentProps, VariableSizeList } from "react-window";
+import { css } from "@emotion/react";
+import { TimeInput } from "./SubtitleListEditor";
+import { memoize } from "lodash";
+import { useTranslation } from "react-i18next";
+import { ModalHandle, ProtoButton, useColorScheme } from "@opencast/appkit";
+import { useTheme } from "../themes";
+import { convertMsToReadableString } from "../util/utilityFunctions";
+import { LuFileQuestion, LuPen, LuSquareSigma, LuTrash } from "react-icons/lu";
+import { ThemedTooltip } from "./Tooltip";
+import { basicButtonStyle, timeInputStyle } from "../cssStyles";
+import {
+  InteractiveElement,
+  removeInteractiveElementById,
+  selectInteractiveElements,
+  updateStartAtIndex,
+} from "../redux/interactiveElementsSlice";
+import InteractiveElementsEditor from "./InteractiveElementEditor";
+
+/**
+ * Displays an overview of interactive elements and assorted actions
+ */
+const InteractiveElementsList: React.FC<{
+  segmentHeight?: number,
+}> = ({
+  segmentHeight = 60,
+}) => {
+  const listRef = useRef<VariableSizeList>(null);
+
+  const elements = useAppSelector(state => selectInteractiveElements(state));
+
+  const listStyle = css({
+    display: "flex",
+    flexDirection: "column",
+    height: "100%",
+    width: "60%",
+    gap: "20px",
+  });
+
+  const calcEstimatedSize = React.useCallback(() => {
+    return segmentHeight;
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const itemData = createItemData(elements);
+  type ItemData = ReturnType<typeof createItemData>
+
+  // useCallback to prevent new function objects getting created on every rerender
+  const renderSubtitleSegment = React.useCallback(
+    ({ index, data, style }: ListChildComponentProps<ItemData>) => (
+      <ListItem
+        index={index}
+        data={data}
+        style={style}
+      />
+    ),
+    [],
+  );
+
+  return (
+    <div css={listStyle}>
+      <AutoSizer>
+        {({ height, width }: { height: string | number, width: string | number; }) => (
+          <VariableSizeList
+            height={height ? height : 0}
+            itemCount={elements.length}
+            itemData={itemData}
+            itemSize={_index => segmentHeight}
+            itemKey={(index, data) => data.items[index].idInternal}
+            width={width ? width : 0}
+            overscanCount={4}
+            estimatedItemSize={calcEstimatedSize()}
+            innerElementType={innerElementType}
+            ref={listRef}
+          >
+            {renderSubtitleSegment}
+          </VariableSizeList>
+        )}
+      </AutoSizer>
+    </div>
+  );
+
+};
+
+/**
+ * Helper function for reducing rerender calls caused by react-window
+ */
+const createItemData = memoize(items => ({
+  items,
+}));
+
+/**
+ * Global variable to synchronize padding for react-window elements
+ */
+const PADDING_SIZE = 20;
+
+// Used for padding in the VariableSizeList
+const innerElementType = React.forwardRef<HTMLDivElement, { style: CSSProperties; }>(({ style, ...rest }, ref) => (
+  <div
+    ref={ref}
+    style={{
+      ...style,
+      paddingTop: PADDING_SIZE + "px",
+      zIndex: "1000",
+    }}
+    {...rest}
+  />
+));
+
+const ListItem: React.FC<{
+  index: number,
+  data: { items: InteractiveElement[] },
+  style: CSSProperties,
+}> = React.memo(props => {
+  // Parse props
+  const { items } = props.data;
+  const item = items[props.index];
+
+  const { t } = useTranslation();
+  const theme = useTheme();
+  const dispatch = useAppDispatch();
+  const { scheme } = useColorScheme();
+
+  const modalRef = useRef<ModalHandle>(null);
+
+  const updateStartTime = (value: number) => {
+    dispatch(updateStartAtIndex({
+      index: props.index,
+      newStart: value,
+    }));
+  };
+
+  const editItem = () => {
+    modalRef.current?.open();
+  };
+
+  const deleteItem = () => {
+    dispatch(removeInteractiveElementById(item.idInternal));
+  };
+
+  const segmentStyle = css({
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "left",
+    alignItems: "center",
+    gap: "20px",
+    "& textarea, input": {
+      outline: `${theme.element_outline}`,
+    },
+    "& input": {
+      marginTop: (scheme === "dark-high-contrast" || scheme === "light-high-contrast" ? "3%" : "0%"),
+      marginBottom: (scheme === "dark-high-contrast" || scheme === "light-high-contrast" ? "3%" : "0%"),
+    },
+  });
+
+  const typeStyle = css({
+    width: "32px",
+    height: "32px",
+    background: `${theme.element_bg}`,
+    border: "1px solid #ccc",
+    zIndex: "1000",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+  });
+
+  const segmentButtonStyle = css({
+    width: "32px",
+    height: "32px",
+    boxShadow: `${theme.boxShadow}`,
+    background: `${theme.element_bg}`,
+    zIndex: "1000",
+  });
+
+  const textFieldStyle = css({
+    flexGrow: "7",
+    minWidth: "100px",
+    maxWidth: "200px",
+    height: "32px",
+    background: `${theme.element_bg}`,
+    border: "1px solid #ccc",
+    borderRadius: "3px",
+    display: "flex",
+    alignItems: "center",
+    paddingLeft: "8px",
+  });
+
+  return (
+    <div tabIndex={-1} css={[segmentStyle, {
+      ...props.style,
+      // Used for padding in the VariableSizeList
+      top: props.style.top !== undefined ?
+        `${parseFloat(props.style.top.toString()) + PADDING_SIZE}px` : "0px",
+      height: props.style.height !== undefined ?
+        `${parseFloat(props.style.height.toString()) - PADDING_SIZE}px` : "0px",
+      zIndex: "1000",
+    }]}>
+      <div css={typeStyle}>
+        {item.type === "Textbox" ? <LuSquareSigma /> : undefined}
+        {item.type === "Quiz" ? <LuFileQuestion /> : undefined}
+      </div>
+      <TimeInput
+        generalFieldStyle={[timeInputStyle(theme)]}
+        value={item.start}
+        changeCallback={updateStartTime}
+        tooltip={t("subtitleList.startTime-tooltip")}
+        tooltipAria={t("subtitleList.startTime-tooltip-aria") + ": " + convertMsToReadableString(item.start)}
+      />
+      <div css={textFieldStyle}>
+        {item.type === "Textbox" ? item.text : undefined}
+        {item.type === "Quiz" ? item.question : undefined}
+      </div>
+      <ThemedTooltip title={t("interactiveElements.editElement-tooltip")}>
+        <ProtoButton
+          aria-label={t("interactiveElements.editElement-tooltip-aria")}
+          onClick={editItem}
+          onKeyDown={makeEnterSpaceHandler(deleteItem)}
+          css={[basicButtonStyle(theme), segmentButtonStyle]}
+        >
+          <LuPen />
+        </ProtoButton>
+      </ThemedTooltip>
+      <ThemedTooltip title={t("interactiveElements.deleteElement-tooltip")}>
+        <ProtoButton
+          aria-label={t("interactiveElements.deleteElement-tooltip-aria")}
+          onClick={deleteItem}
+          onKeyDown={makeEnterSpaceHandler(deleteItem)}
+          css={[basicButtonStyle(theme), segmentButtonStyle]}
+        >
+          <LuTrash />
+        </ProtoButton>
+      </ThemedTooltip>
+      <InteractiveElementsEditor
+        element={item}
+        modalRef={modalRef}
+      />
+    </div>
+  );
+});
+
+function makeEnterSpaceHandler(callback: () => void) {
+  return (event: React.KeyboardEvent) => {
+    if (event.key === " " || event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      callback();
+    }
+  };
+}
+
+export default InteractiveElementsList;

--- a/src/main/InteractiveElementsList.tsx
+++ b/src/main/InteractiveElementsList.tsx
@@ -6,7 +6,7 @@ import { css } from "@emotion/react";
 import { TimeInput } from "./SubtitleListEditor";
 import { memoize } from "lodash";
 import { useTranslation } from "react-i18next";
-import { ModalHandle, ProtoButton, useColorScheme } from "@opencast/appkit";
+import { ConfirmationModal, ConfirmationModalHandle, ModalHandle, ProtoButton, useColorScheme } from "@opencast/appkit";
 import { useTheme } from "../themes";
 import { convertMsToReadableString } from "../util/utilityFunctions";
 import { LuFileQuestion, LuPen, LuSquareSigma, LuTrash } from "react-icons/lu";
@@ -126,6 +126,7 @@ const ListItem: React.FC<{
   const { scheme } = useColorScheme();
 
   const modalRef = useRef<ModalHandle>(null);
+  const deleteModalRef = useRef<ConfirmationModalHandle>(null);
 
   const segments = useAppSelector(selectSegments);
   let wouldBeDeleted = false;
@@ -236,8 +237,7 @@ const ListItem: React.FC<{
       <ThemedTooltip title={t("interactiveElements.deleteElement-tooltip")}>
         <ProtoButton
           aria-label={t("interactiveElements.deleteElement-tooltip-aria")}
-          onClick={deleteItem}
-          onKeyDown={makeEnterSpaceHandler(deleteItem)}
+          onClick={() => deleteModalRef.current?.open()}
           css={[basicButtonStyle(theme), segmentButtonStyle]}
         >
           <LuTrash />
@@ -247,6 +247,22 @@ const ListItem: React.FC<{
         element={item}
         modalRef={modalRef}
       />
+      <ConfirmationModal
+        title={t("interactiveElements.deleteElement-warning-header")}
+        buttonContent={t("modal.confirm")}
+        onSubmit={() => {
+          deleteModalRef.current?.done();
+          deleteItem();
+        }}
+        ref={deleteModalRef}
+        text={{
+          cancel: t("modal.cancel"),
+          close: t("modal.close"),
+          areYouSure: t("modal.areYouSure"),
+        }}
+      >
+        {t("interactiveElements.deleteElement-warning")}
+      </ConfirmationModal>
     </div>
   );
 });

--- a/src/main/InteractiveElementsTimeline.tsx
+++ b/src/main/InteractiveElementsTimeline.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { useAppDispatch, useAppSelector } from "../redux/store";
-import { selectDuration } from "../redux/videoSlice";
+import { selectDuration, selectSegments } from "../redux/videoSlice";
 import Draggable, { DraggableEventHandler } from "react-draggable";
 import { useTheme } from "../themes";
 import { InteractiveElement, selectInteractiveElements, updateStartAtIndex } from "../redux/interactiveElementsSlice";
@@ -54,12 +54,20 @@ const InteractiveElementSegment: React.FC<{
   const dispatch = useAppDispatch();
   const theme = useTheme();
   const duration = useAppSelector(selectDuration);
+  const segments = useAppSelector(selectSegments);
+  let wouldBeDeleted = false;
 
   const modalRef = useRef<ModalHandle>(null);
   const [controlledPosition, setControlledPosition] = useState({ x: 0, y: 0 });
   const [isGrabbed, setIsGrabbed] = useState(false);
   const nodeRef = useRef(null); // For supressing "ReactDOM.findDOMNode() is deprecated" warning
   const draggedRef = useRef<boolean>(false); // For preventing onClicks when done dragging
+
+  for (const segment of segments) {
+    if (segment.start < props.item.start && segment.end > props.item.start) {
+      wouldBeDeleted = segment.deleted;
+    }
+  }
 
   useEffect(() => {
     setControlledPosition({ x: (props.item.start / duration) * (props.timelineWidth), y: 0 });
@@ -90,7 +98,7 @@ const InteractiveElementSegment: React.FC<{
     position: "absolute",
     width: "32px",
     height: "32px",
-    background: `${theme.element_bg}`,
+    background: wouldBeDeleted ? "rgba(200, 0, 0, 1)" : `${theme.element_bg}`,
     border: "1px solid #ccc",
     zIndex: "1000",
     display: "flex",

--- a/src/main/InteractiveElementsTimeline.tsx
+++ b/src/main/InteractiveElementsTimeline.tsx
@@ -96,7 +96,8 @@ const InteractiveElementSegment: React.FC<{
 
   const segmentStyle = css({
     position: "absolute",
-    width: "32px",
+    width: props.item.type === "Textbox" ? `${(10000 / duration) * 100}%` : "32px",
+    minWidth: "32px",
     height: "32px",
     background: wouldBeDeleted ? "rgba(200, 0, 0, 1)" : `${theme.element_bg}`,
     border: "1px solid #ccc",

--- a/src/main/InteractiveElementsTimeline.tsx
+++ b/src/main/InteractiveElementsTimeline.tsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useRef, useState } from "react";
+import { css } from "@emotion/react";
+import { useAppDispatch, useAppSelector } from "../redux/store";
+import { selectDuration } from "../redux/videoSlice";
+import Draggable, { DraggableEventHandler } from "react-draggable";
+import { useTheme } from "../themes";
+import { InteractiveElement, selectInteractiveElements, updateStartAtIndex } from "../redux/interactiveElementsSlice";
+import { LuFileQuestion, LuSquareSigma } from "react-icons/lu";
+import InteractiveElementsEditor from "./InteractiveElementEditor";
+import { ModalHandle } from "@opencast/appkit";
+
+const InteractiveElementsTimeline: React.FC<{
+  timelineWidth: number
+  timelineHeight: number
+}> = ({
+  timelineWidth,
+  timelineHeight,
+}) => {
+  const arbitraryHeight = 80;
+  const elements = useAppSelector(state => selectInteractiveElements(state));
+
+  const segmentsListStyle = css({
+    position: "absolute",
+    width: "100%",
+    height: timelineHeight,
+    overflow: "hidden",
+    display: "flex",
+    alignItems: "center",
+  });
+
+  return (
+    <div css={segmentsListStyle}>
+      {elements.map((item, i) => {
+        return (
+          <InteractiveElementSegment
+            timelineWidth={timelineWidth}
+            item={item}
+            height={arbitraryHeight}
+            key={i}
+            index={i}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+const InteractiveElementSegment: React.FC<{
+  timelineWidth: number,
+  item: InteractiveElement,
+  index: number,
+  height: number;
+}> = React.memo(props => {
+  const dispatch = useAppDispatch();
+  const theme = useTheme();
+  const duration = useAppSelector(selectDuration);
+
+  const modalRef = useRef<ModalHandle>(null);
+  const [controlledPosition, setControlledPosition] = useState({ x: 0, y: 0 });
+  const [isGrabbed, setIsGrabbed] = useState(false);
+  const nodeRef = useRef(null); // For supressing "ReactDOM.findDOMNode() is deprecated" warning
+  const draggedRef = useRef<boolean>(false); // For preventing onClicks when done dragging
+
+  useEffect(() => {
+    setControlledPosition({ x: (props.item.start / duration) * (props.timelineWidth), y: 0 });
+  }, [props.item.start, duration, props.timelineWidth]);
+
+  const editItem = () => {
+    const dragged = draggedRef.current;
+    draggedRef.current = false;
+    if (!dragged) {
+      modalRef.current?.open();
+    }
+  };
+
+  const onStartDrag: DraggableEventHandler = _e => {
+    setIsGrabbed(true);
+  };
+
+  const onStopDrag: DraggableEventHandler = (_e, position) => {
+    dispatch(updateStartAtIndex({
+      index: props.index,
+      newStart: (position.x / props.timelineWidth) * (duration),
+    }));
+
+    setIsGrabbed(false);
+  };
+
+  const segmentStyle = css({
+    position: "absolute",
+    width: "32px",
+    height: "32px",
+    background: `${theme.element_bg}`,
+    border: "1px solid #ccc",
+    zIndex: "1000",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+
+    cursor: isGrabbed ? "grabbing" : "grab",
+  });
+
+  return (
+    <>
+      <Draggable
+        onStart={onStartDrag}
+        onDrag={() => { draggedRef.current = true; }}
+        onStop={onStopDrag}
+        defaultPosition={{ x: 10, y: 10 }}
+        position={controlledPosition}
+        axis="x"
+        bounds="parent"
+        nodeRef={nodeRef}
+        cancel={".react-resizable-handle"}
+      >
+        <div css={segmentStyle} ref={nodeRef} onClick={editItem} className="prevent-drag-scroll">
+          {props.item.type === "Textbox" ? <LuSquareSigma /> : undefined}
+          {props.item.type === "Quiz" ? <LuFileQuestion /> : undefined}
+        </div>
+      </Draggable>
+      <InteractiveElementsEditor
+        element={props.item}
+        modalRef={modalRef}
+      />
+    </>
+  );
+});
+
+export default InteractiveElementsTimeline;

--- a/src/main/InteractiveElementsTimeline.tsx
+++ b/src/main/InteractiveElementsTimeline.tsx
@@ -5,7 +5,7 @@ import { selectDuration, selectSegments } from "../redux/videoSlice";
 import Draggable, { DraggableEventHandler } from "react-draggable";
 import { useTheme } from "../themes";
 import { InteractiveElement, selectInteractiveElements, updateStartAtIndex } from "../redux/interactiveElementsSlice";
-import { LuFileQuestion, LuSquareSigma } from "react-icons/lu";
+import { LuFileQuestion, LuType } from "react-icons/lu";
 import InteractiveElementsEditor from "./InteractiveElementEditor";
 import { ModalHandle } from "@opencast/appkit";
 
@@ -122,7 +122,7 @@ const InteractiveElementSegment: React.FC<{
         cancel={".react-resizable-handle"}
       >
         <div css={segmentStyle} ref={nodeRef} onClick={editItem} className="prevent-drag-scroll">
-          {props.item.type === "Textbox" ? <LuSquareSigma /> : undefined}
+          {props.item.type === "Textbox" ? <LuType /> : undefined}
           {props.item.type === "Quiz" ? <LuFileQuestion /> : undefined}
         </div>
       </Draggable>

--- a/src/main/MainContent.tsx
+++ b/src/main/MainContent.tsx
@@ -23,6 +23,7 @@ import { useTheme } from "../themes";
 import Thumbnail from "./Thumbnail";
 import Cutting from "./Cutting";
 import Chapter from "./Chapter";
+import InteractiveElements from "./InteractiveElements";
 
 /**
  * A container for the main functionality
@@ -142,6 +143,12 @@ const MainContent: React.FC = () => {
           ref={mainRef} tabIndex={-1} style={{ outline: "none" }}
         >
           <Thumbnail />
+        </div>
+      );
+    } else if (mainMenuState === MainMenuStateNames.interactiveElements) {
+      return (
+        <div css={[mainContentStyle, subtitleSelectStyle]} role="main">
+          <InteractiveElements />
         </div>
       );
     } else if (mainMenuState === MainMenuStateNames.finish) {

--- a/src/main/MainMenu.tsx
+++ b/src/main/MainMenu.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { css, SerializedStyles } from "@emotion/react";
 
 import { IconType } from "react-icons";
-import { LuScissors, LuFilm, LuFileText, LuSquareCheckBig, LuBookOpenText } from "react-icons/lu";
+import { LuScissors, LuFilm, LuFileText, LuSquareCheckBig, LuBookOpenText, LuSquareMousePointer } from "react-icons/lu";
 import { LuImage } from "react-icons/lu";
 import SubtitleIcon from "../img/subtitle.svg?react";
 
@@ -88,6 +88,12 @@ const MainMenu: React.FC = () => {
         stateName={MainMenuStateNames.thumbnail}
         bottomText={t(MainMenuStateNames.thumbnail)}
         ariaLabelText={t(MainMenuStateNames.thumbnail)}
+      />}
+      {settings.interactiveElements.show && <MainMenuButton
+        Icon={LuSquareMousePointer}
+        stateName={MainMenuStateNames.interactiveElements}
+        bottomText={t(MainMenuStateNames.interactiveElements)}
+        ariaLabelText={t(MainMenuStateNames.interactiveElements)}
       />}
       <MainMenuButton
         Icon={LuSquareCheckBig}

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -12,8 +12,10 @@ import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
   selectCustomizedTrackSelection,
   selectHasChanges,
+  selectQuizzesFromOpencast,
   selectSegments,
   selectSelectedWorkflowId,
+  selectTextBoxesFromOpencast,
   selectTracks,
   setHasChanges as videoSetHasChanges,
 } from "../redux/videoSlice";
@@ -40,6 +42,12 @@ import { ProtoButton } from "@opencast/appkit";
 import { setEnd } from "../redux/endSlice";
 import { selectSubtitles as selectChapters } from "../redux/chapterSlice";
 import { SubtitlesInEditor } from "../types";
+import {
+  InteractiveElement,
+  InteractiveElementFromOpencast,
+  selectInteractiveElements,
+} from "../redux/interactiveElementsSlice";
+import { nanoid } from "@reduxjs/toolkit";
 
 /**
  * Shown if the user wishes to save.
@@ -131,6 +139,9 @@ export const SaveButton: React.FC<{
   const subtitles = useAppSelector(selectSubtitles);
   const chapters = useAppSelector(selectChapters);
   const metadata = useAppSelector(selectAllCatalogs);
+  const interactiveElements = useAppSelector(selectInteractiveElements);
+  const textboxesFromOpencast = useAppSelector(selectTextBoxesFromOpencast);
+  const quizzesFromOpencast = useAppSelector(selectQuizzesFromOpencast);
   const selectedWorkflowId = useAppSelector(selectSelectedWorkflowId);
   const workflowStatus = useAppSelector(selectStatus);
   const theme = useTheme();
@@ -165,6 +176,20 @@ export const SaveButton: React.FC<{
       deleted,
     }));
 
+  const prepareInteractiveElement = (
+    elements: InteractiveElement[],
+    type: InteractiveElement["type"],
+    id?: string,
+  ): InteractiveElementFromOpencast => {
+    const preparedElements = elements
+      .filter(element => element.type === type)
+      .map(({ type, idInternal, ...rest }) => rest);
+    return ({
+      id: id ?? nanoid(),
+      elementsJSON: JSON.stringify(preparedElements),
+    });
+  };
+
   const save = () => {
     dispatch(postVideoInformation({
       segments: segments,
@@ -173,6 +198,8 @@ export const SaveButton: React.FC<{
       subtitles: prepareSubtitles(subtitles),
       chapters: prepareSubtitles(chapters),
       metadata: metadata,
+      textboxes: prepareInteractiveElement(interactiveElements, "Textbox", textboxesFromOpencast?.id),
+      quizzes: prepareInteractiveElement(interactiveElements, "Quiz", quizzesFromOpencast?.id),
       workflow: startWorkflow && selectedWorkflowId ? [{ id: selectedWorkflowId }] : undefined,
     }));
   };

--- a/src/main/SubtitleListEditor.tsx
+++ b/src/main/SubtitleListEditor.tsx
@@ -7,7 +7,7 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { shallowEqual } from "react-redux";
 import { RootState, useAppDispatch, useAppSelector } from "../redux/store";
-import { basicButtonStyle } from "../cssStyles";
+import { basicButtonStyle, timeInputStyle } from "../cssStyles";
 import { subtitleListHotkeysDefaultOptions } from "../globalKeys";
 import { SubtitleCue, SubtitlesInEditor } from "../types";
 import { convertMsToReadableString } from "../util/utilityFunctions";
@@ -187,7 +187,6 @@ const SubtitleListEditor: React.FC<{
       setFocusToSegmentBelowId,
     ],
   );
-
 
   return (
     <div css={listStyle}>
@@ -524,30 +523,13 @@ const SubtitleListSegment : React.FC<{
     visibility: "hidden",
   });
 
-  const fieldStyle = css({
-    fontSize: "1em",
-    marginLeft: "15px",
-    marginRight: "2px",
-    borderRadius: "5px",
-    borderWidth: "1px",
-    padding: "10px 10px",
-    background: `${theme.element_bg}`,
-    border: "1px solid #ccc",
-    color: `${theme.text}`,
+  const subtitleTimeInputStyle = css({
+    height: isChapterInputs ? "20px" : "16px",
+    width: "96px",
   });
 
   const timeWrapperStyle = css({
     display: "flex",
-  });
-
-  const timeInputStyle = css({
-    fontSize: "1em",
-    padding: "10px",
-    borderRight: "none",
-    borderRadius: "5px 0 0 5px",
-    background: `${theme.element_bg}`,
-    border: "1px solid #ccc",
-    color: `${theme.text}`,
   });
 
   const copyTimeButtonStyle = css({
@@ -581,7 +563,7 @@ const SubtitleListSegment : React.FC<{
 
       <textarea
         ref={textAreaRef}
-        css={[fieldStyle, textFieldStyle]}
+        css={[timeInputStyle(theme), textFieldStyle]}
         defaultValue={cue.text}
         onKeyDown={(event: React.KeyboardEvent) => {
           if (event.key === "Enter" && !event.shiftKey && isFunctionButtonEnabled) {
@@ -597,7 +579,7 @@ const SubtitleListSegment : React.FC<{
         <div css={timeAreaStyle}>
           <div css={timeWrapperStyle}>
             <TimeInput
-              generalFieldStyle={[timeInputStyle,
+              generalFieldStyle={[timeInputStyle(theme), subtitleTimeInputStyle,
                 css({ ...(cue.startTime > cue.endTime && { borderColor: "red", borderWidth: "2px" }) })]}
               value={cue.startTime}
               changeCallback={updateCueStart}
@@ -615,7 +597,7 @@ const SubtitleListSegment : React.FC<{
           </div>
           <div css={timeWrapperStyle}>
             <TimeInput
-              generalFieldStyle={[timeInputStyle,
+              generalFieldStyle={[timeInputStyle(theme), subtitleTimeInputStyle,
                 css({ ...(cue.startTime > cue.endTime && { borderColor: "red", borderWidth: "2px" }) })]}
               value={cue.endTime}
               changeCallback={updateCueEnd}
@@ -635,8 +617,7 @@ const SubtitleListSegment : React.FC<{
         :
         <TimeInput
           disabled={props.index === 0 ? true : false}
-          isChapterInputs={isChapterInputs}
-          generalFieldStyle={[fieldStyle,
+          generalFieldStyle={[timeInputStyle(theme), subtitleTimeInputStyle,
             css({ ...(prevCue && (prevCue.startTime > cue.startTime) && { borderColor: "red", borderWidth: "2px" }) })]}
           value={cue.startTime}
           changeCallback={updateCueStartChapter}
@@ -732,14 +713,13 @@ const FunctionButton: React.FC<{
 /**
  * Input field for the time values for a subtitle segment
  */
-const TimeInput: React.FC<{
+export const TimeInput: React.FC<{
   value: number,
   changeCallback: (value: number) => void,
   generalFieldStyle: SerializedStyles[],
   tooltip: string,
   tooltipAria: string,
   disabled?: boolean,
-  isChapterInputs?: boolean,
 }> = ({
   value,
   changeCallback,
@@ -747,7 +727,6 @@ const TimeInput: React.FC<{
   tooltip,
   tooltipAria,
   disabled,
-  isChapterInputs,
 }) => {
 
   // Stores the millisecond value as a string for the input element
@@ -785,8 +764,6 @@ const TimeInput: React.FC<{
   };
 
   const timeFieldStyle = css({
-    height: isChapterInputs ? "20px" : "16px",
-    width: "96px",
     ...(parsingError && { borderColor: "red", borderWidth: "2px" }),
   });
 

--- a/src/main/SubtitleVideoArea.tsx
+++ b/src/main/SubtitleVideoArea.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { css } from "@emotion/react";
-import { RootState, ThunkApiConfig, useAppSelector } from "../redux/store";
+import { RootState, useAppSelector } from "../redux/store";
 import {
   selectIsMuted,
   selectVideos,
@@ -15,11 +15,11 @@ import { settings } from "../config";
 import { useTranslation } from "react-i18next";
 import { serializeSubtitle } from "../util/utilityFunctions";
 import { useTheme } from "../themes";
-import { VideoPlayer } from "./VideoPlayers";
+import { VideoPlayer, VideoPlayerProps } from "./VideoPlayers";
 import VideoControls from "./VideoControls";
 import Select from "react-select";
 import { selectFieldStyle } from "../cssStyles";
-import { ActionCreatorWithPayload, AsyncThunk } from "@reduxjs/toolkit";
+import { ActionCreatorWithPayload } from "@reduxjs/toolkit";
 import { setCurrentlyAt } from "../redux/subtitleSlice";
 
 /**
@@ -39,13 +39,13 @@ const SubtitleVideoArea: React.FC<{
   selectPreviewTriggered: (state: RootState) => boolean,
   selectAspectRatio: (state: RootState) => number,
   selectIsPlayPreview: (state: RootState) => boolean,
-  selectSelectedSubtitleById: (state: RootState) => SubtitlesInEditor,
+  selectSelectedSubtitleById: (state: RootState) => SubtitlesInEditor | undefined,
   setIsPlaying: ActionCreatorWithPayload<boolean, string>,
-  setPreviewTriggered: ActionCreatorWithPayload<boolean, string>,
-  setAspectRatio: ActionCreatorWithPayload<{ dataKey: number; } & { width: number, height: number; }, string>,
+  setPreviewTriggered: VideoPlayerProps["setPreviewTriggered"],
+  setAspectRatio: VideoPlayerProps["setAspectRatio"],
   setIsPlayPreview: ActionCreatorWithPayload<boolean, string>,
-  setClickTriggered: ActionCreatorWithPayload<boolean, string>,
-  setCurrentlyAtAndTriggerPreview: AsyncThunk<void, number, ThunkApiConfig>,
+  setClickTriggered: VideoPlayerProps["setClickTriggered"],
+  setCurrentlyAtAndTriggerPreview: VideoPlayerProps["setCurrentlyAt"],
 }> = ({
   selectIsPlaying,
   selectCurrentlyAt,

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -44,6 +44,7 @@ import {
 } from "../redux/chapterSlice";
 import TimelineStamps from "./TimelineStamps";
 import { selectKeymap } from "../redux/hotkeySlice";
+import InteractiveElementsTimeline from "./InteractiveElementsTimeline";
 
 /**
  * A container for visualizing the cutting of the video, as well as for controlling
@@ -60,6 +61,7 @@ const Timeline: React.FC<{
   setCurrentlyAt: ActionCreatorWithPayload<number, string>,
   setIsPlaying: ActionCreatorWithPayload<boolean, string>,
   isChapters?: boolean,
+  isInteractiveElements?: boolean,
 }> = ({
   timelineHeight = 200,
   styleByActiveSegment = true,
@@ -69,6 +71,7 @@ const Timeline: React.FC<{
   setCurrentlyAt,
   setIsPlaying,
   isChapters = false,
+  isInteractiveElements = false,
 }) => {
 
   // Init redux variables
@@ -218,6 +221,12 @@ const Timeline: React.FC<{
                 selectSegments={chapterSelectSegments}
                 selectActiveSegmentIndex={chapterSelectActiveSegmentIndex}
                 moveCut={chapterMoveCut}
+              />
+            }
+            {isInteractiveElements &&
+              <InteractiveElementsTimeline
+                timelineWidth={width}
+                timelineHeight={timelineHeight}
               />
             }
             <SegmentsList

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -169,7 +169,7 @@ const Timeline: React.FC<{
   };
 
   return (
-    <CuttingActionsContextMenu>
+    <CuttingActionsContextMenu isChapters={isChapters} isInteractiveElements={isInteractiveElements}>
       <div css={css({ position: "absolute" })}>
         <TimelineStamps
           durationMs={duration}

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -118,7 +118,7 @@ export interface VideoPlayerForwardRef {
   getWidth: () => number,
 }
 
-interface VideoPlayerProps {
+export interface VideoPlayerProps {
   dataKey: number,
   url: string | undefined,
   isPrimary: boolean,

--- a/src/redux/interactiveElementsSlice.ts
+++ b/src/redux/interactiveElementsSlice.ts
@@ -1,0 +1,101 @@
+import { createSlice, nanoid, PayloadAction } from "@reduxjs/toolkit";
+
+export type Textbox = {
+  start: number,
+  text: string,
+  link?: string,
+  type: "Textbox",    // Internal, for discerning unions
+  idInternal: string, // Identifier for internal use.
+}
+
+export type Quiz = {
+  start: number,
+  question: string,
+  answers : {
+    text: string,
+    correct: boolean,
+  }[]
+  type: "Quiz"        // Internal, for discerning unions
+  idInternal: string, // Identifier for internal use.
+}
+
+export type InteractiveElement = Textbox | Quiz;
+
+export type InteractiveElementFromOpencast = {
+  id: string,
+  elementsJSON: string,
+};
+
+export interface interactiveElements {
+  interactiveElements: InteractiveElement[],
+  hasChanges: boolean;         // Did user make changes to metadata view since last save
+}
+
+const initialState: interactiveElements = {
+  interactiveElements: [],
+  hasChanges: false,
+};
+
+
+/**
+ * Slice for the interactive elements editor state
+ */
+export const interactiveElementsSlice = createSlice({
+  name: "interactiveElementsState",
+  initialState,
+  reducers: {
+    setInteractiveElements: (state, action: PayloadAction<interactiveElements["interactiveElements"]>) => {
+      state.interactiveElements = action.payload;
+    },
+    updateStartAtIndex: (state, action: PayloadAction<{index: number, newStart: number}>) => {
+      if (action.payload.index < 0 || action.payload.index >= state.interactiveElements.length) {
+        console.warn("Index " + action.payload.index + " was out of range");
+        return;
+      }
+      state.interactiveElements[action.payload.index].start = Math.round(action.payload.newStart);
+
+      state.interactiveElements = sortSubtitle(state.interactiveElements);
+      state.hasChanges = true;
+    },
+    addInteractiveElement: (state, action: PayloadAction<InteractiveElement>) => {
+      const existingElementIndex = state.interactiveElements.findIndex(e => e.idInternal === action.payload.idInternal);
+      if (existingElementIndex < 0) {
+        action.payload.idInternal = nanoid();
+        state.interactiveElements.push(action.payload);
+      } else {
+        state.interactiveElements[existingElementIndex] = action.payload;
+      }
+
+      state.interactiveElements = sortSubtitle(state.interactiveElements);
+      state.hasChanges = true;
+    },
+    removeInteractiveElementById: (state, action: PayloadAction<string>) => {
+      const existingElementIndex = state.interactiveElements.findIndex(e => e.idInternal === action.payload);
+      if (existingElementIndex >= 0) {
+        state.interactiveElements.splice(existingElementIndex, 1);
+      }
+    },
+  },
+  selectors: {
+    selectInteractiveElements: state => state.interactiveElements,
+  },
+});
+
+// Sort a subtitle array by startTime
+const sortSubtitle = (elements: InteractiveElement[]) => {
+  return elements.sort((a, b) => a.start - b.start);
+};
+
+// Export Actions
+export const {
+  setInteractiveElements,
+  updateStartAtIndex,
+  addInteractiveElement,
+  removeInteractiveElementById,
+} = interactiveElementsSlice.actions;
+
+export const {
+  selectInteractiveElements,
+} = interactiveElementsSlice.selectors;
+
+export default interactiveElementsSlice.reducer;

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -9,6 +9,7 @@ import subtitleReducer from "./subtitleSlice";
 import chapterReducer from "./chapterSlice";
 import thumbnailReducer from "./thumbnailSlice";
 import hotkeyReducer from "./hotkeySlice";
+import interactiveElementsReducer from "./interactiveElementsSlice";
 import errorReducer from "./errorSlice";
 import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux";
 import storage from "redux-persist/lib/storage";
@@ -26,6 +27,7 @@ const reducers = combineReducers({
   thumbnailState: thumbnailReducer,
   hotkeyState: hotkeyReducer,
   errorState: errorReducer,
+  interactiveElementsState: interactiveElementsReducer,
 });
 
 const persistConfig = {

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -6,6 +6,7 @@ import { Segment, httpRequestState, Track, Workflow, SubtitlesFromOpencast } fro
 import { roundToDecimalPlace } from "../util/utilityFunctions";
 import { settings } from "../config";
 import { createAppAsyncThunk } from "./createAsyncThunkWithTypes";
+import { InteractiveElementFromOpencast } from "./interactiveElementsSlice";
 
 export interface video {
   isPlaying: boolean,             // Are videos currently playing?
@@ -21,6 +22,8 @@ export interface video {
   customizedTrackSelection: boolean, // Did user select tracks for processing
   subtitlesFromOpencast: SubtitlesFromOpencast[],
   chaptersFromOpencast: SubtitlesFromOpencast[],
+  textBoxesFromOpencast: InteractiveElementFromOpencast | undefined,
+  quizzesFromOpencast: InteractiveElementFromOpencast | undefined,
   activeSegmentIndex: number,     // Index of the segment that is currenlty hovered
   selectedWorkflowId: string,     // Id of the currently selected workflow
   aspectRatios: { width: number, height: number; }[],  // Aspect ratios of every video
@@ -58,6 +61,8 @@ export const initialState: video & httpRequestState = {
   customizedTrackSelection: false,
   subtitlesFromOpencast: [],
   chaptersFromOpencast: [],
+  textBoxesFromOpencast: undefined,
+  quizzesFromOpencast: undefined,
   activeSegmentIndex: 0,
   selectedWorkflowId: "",
   previewTriggered: false,
@@ -103,6 +108,8 @@ type FetchVideoInformation = {
   chapters:video["subtitlesFromOpencast"],
   local: boolean,
   customizedTrackSelection: boolean, // TODO: Figure out if this still exists
+  textboxes?: video["textBoxesFromOpencast"]
+  quizzes?: video["quizzesFromOpencast"]
 }
 
 export const fetchVideoInformation = createAppAsyncThunk("video/fetchVideoInformation", async () => {
@@ -365,6 +372,8 @@ const videoSlice = createSlice({
           state.subtitlesFromOpencast = payload.subtitles : [];
         state.chaptersFromOpencast = payload.chapters ?
           state.chaptersFromOpencast = payload.chapters : [];
+        state.textBoxesFromOpencast = payload.textboxes ? payload.textboxes : undefined;
+        state.quizzesFromOpencast = payload.quizzes ? payload.quizzes : undefined;
         state.duration = payload.duration;
         state.title = payload.title;
         state.segments = parseSegments(payload.segments, payload.duration);
@@ -455,6 +464,9 @@ const videoSlice = createSlice({
       }, undefined);
       return primaryTrack;
     },
+    selectTextBoxesFromOpencast: state => state.textBoxesFromOpencast,
+    selectQuizzesFromOpencast: state => state.quizzesFromOpencast,
+    dummy: () => undefined,
   },
 });
 
@@ -640,9 +652,12 @@ export const {
   selectSubtitlesFromOpencastById,
   selectChaptersFromOpencast,
   selectChaptersFromOpencastById,
+  selectTextBoxesFromOpencast,
+  selectQuizzesFromOpencast,
   selectVideos,
   selectDisplayDuration,
   selectPrimaryThumbnailTrack,
+  dummy,
 } = videoSlice.selectors;
 
 export default videoSlice.reducer;

--- a/src/redux/workflowPostSlice.ts
+++ b/src/redux/workflowPostSlice.ts
@@ -48,6 +48,8 @@ export const postVideoInformation =
         chapters: argument.chapters,
         workflows: argument.workflow,
         metadataJSON: JSON.stringify(catalogsJson),
+        textboxes: argument.textboxes,
+        quizzes: argument.quizzes,
       },
     );
     return response;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { InteractiveElementFromOpencast } from "./redux/interactiveElementsSlice";
 import { Catalog } from "./redux/metadataSlice";
 
 export interface Segment {
@@ -75,7 +76,9 @@ export interface PostEditArgument {
   subtitles: SubtitlesFromOpencast[]
   chapters: SubtitlesFromOpencast[]
   workflow?: [{id: string}]
-  metadata: Catalog[]
+  metadata: Catalog[],
+  textboxes: InteractiveElementFromOpencast
+  quizzes: InteractiveElementFromOpencast
 }
 
 // Use respective i18n keys as values
@@ -86,6 +89,7 @@ export enum MainMenuStateNames {
   subtitles = "mainMenu.subtitles-button",
   chapters = "mainMenu.chapters-button",
   thumbnail = "mainMenu.thumbnail-button",
+  interactiveElements = "mainMenu.interactiveElements-button",
   finish = "mainMenu.finish-button",
   keyboardControls = "mainMenu.keyboard-controls-button",
 }


### PR DESCRIPTION
Adds a new view to the editor. The view is for users to create and manage interactive elements in the Paella player such as textboxes and links, see https://github.com/opencast/opencast/pull/7223.

<img width="1638" height="1100" alt="Bildschirmfoto vom 2025-12-01 09-47-56" src="https://github.com/user-attachments/assets/3714cbae-2f21-4d2f-b252-e8bc748599f2" />
