### PR TITLE
Thumbnails in backend

### DIFF
--- a/src/main/ThumbnailGeneration.tsx
+++ b/src/main/ThumbnailGeneration.tsx
@@ -22,6 +22,7 @@ import {
   setJumpTriggered,
   setAspectRatio,
   selectPrimaryThumbnailTrack,
+  setThumbnailTime,
 } from "../redux/videoSlice";
 import { Track } from "../types";
 import Timeline from "./Timeline";
@@ -210,8 +211,10 @@ const ThumbnailActions: React.FC<{
   //   *track: Generate to
   //   *index: Generate from
   const generate = (track: Track, index: number) => {
+    const time = generateRefs.current[index]?.getCurrentTime();
     const uri = generateRefs.current[index]?.captureVideo();
     dispatch(setThumbnail({ id: track.id, uri: uri }));
+    dispatch(setThumbnailTime({ id: track.id, time: time?.toString() }));
     dispatch(setHasChanges(true));
   };
 

--- a/src/main/ThumbnailGeneration.tsx
+++ b/src/main/ThumbnailGeneration.tsx
@@ -212,9 +212,10 @@ const ThumbnailActions: React.FC<{
   //   *index: Generate from
   const generate = (track: Track, index: number) => {
     const time = generateRefs.current[index]?.getCurrentTime();
+    const timeObject = time ? { time: time.toString(), flavorType: track.flavor.type } : undefined;
     const uri = generateRefs.current[index]?.captureVideo();
     dispatch(setThumbnail({ id: track.id, uri: uri }));
-    dispatch(setThumbnailTime({ id: track.id, time: time?.toString() }));
+    dispatch(setThumbnailTime({ id: track.id, time: timeObject }));
     dispatch(setHasChanges(true));
   };
 

--- a/src/main/ThumbnailGeneration.tsx
+++ b/src/main/ThumbnailGeneration.tsx
@@ -22,6 +22,7 @@ import {
   setJumpTriggered,
   setAspectRatio,
   selectPrimaryThumbnailTrack,
+  setThumbnailTime,
 } from "../redux/videoSlice";
 import { Track } from "../types";
 import Timeline from "./Timeline";
@@ -218,8 +219,10 @@ const ThumbnailActions: React.FC<{
   //   *track: Generate to
   //   *index: Generate from
   const generate = (track: Track, index: number) => {
+    const time = generateRefs.current[index]?.getCurrentTime();
     const uri = generateRefs.current[index]?.captureVideo();
     dispatch(setThumbnail({ id: track.id, uri: uri }));
+    dispatch(setThumbnailTime({ id: track.id, time: time?.toString() }));
     dispatch(setHasChanges(true));
   };
 

--- a/src/main/ThumbnailGeneration.tsx
+++ b/src/main/ThumbnailGeneration.tsx
@@ -220,9 +220,10 @@ const ThumbnailActions: React.FC<{
   //   *index: Generate from
   const generate = (track: Track, index: number) => {
     const time = generateRefs.current[index]?.getCurrentTime();
+    const timeObject = time ? { time: time.toString(), flavorType: track.flavor.type } : undefined;
     const uri = generateRefs.current[index]?.captureVideo();
     dispatch(setThumbnail({ id: track.id, uri: uri }));
-    dispatch(setThumbnailTime({ id: track.id, time: time?.toString() }));
+    dispatch(setThumbnailTime({ id: track.id, time: timeObject }));
     dispatch(setHasChanges(true));
   };
 

--- a/src/main/ThumbnailSelect.tsx
+++ b/src/main/ThumbnailSelect.tsx
@@ -1,7 +1,7 @@
 import { css, SerializedStyles } from "@emotion/react";
 import { IconType } from "react-icons";
 import { LuCamera, LuCopy, LuCircleX, LuUpload } from "react-icons/lu";
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
@@ -16,11 +16,13 @@ import {
   setHasChanges,
   setThumbnail,
   setThumbnails,
+  setThumbnailTime,
 } from "../redux/videoSlice";
 import { Track } from "../types";
 import { ThemedTooltip } from "./Tooltip";
 import { ProtoButton } from "@opencast/appkit";
 import { setIndex, setIsDisplayEditView } from "../redux/thumbnailSlice";
+import ReactPlayer from "react-player";
 
 /**
  * Choose between various thumbnail actions for the available tracks.
@@ -98,6 +100,7 @@ const ThumbnailSelector: React.FC<{
         track={track}
         trackIndex={trackIndex}
       />
+      <WorkaroundThumbnailGenerator track={track} />
     </div>
   );
 };
@@ -265,6 +268,7 @@ export const UploadButton: React.FC<{
       if (e.target && e.target.result) {
         const uri = e.target.result as string; // We know this must be string because we use "readAsDataURL"
         dispatch(setThumbnail({ id: track.id, uri: uri }));
+        dispatch(setThumbnailTime({ id: track.id, time: undefined }));
         dispatch(setHasChanges(true));
       }
     };
@@ -451,6 +455,63 @@ export const ThumbnailButton: React.FC<{
         {text}
       </ProtoButton>
     </ThemedTooltip>
+  );
+};
+
+/**
+ * Generates a temporary thumbnail from a timestamp
+ *
+ * Workaround for the backend being unable to send us thumbnails from
+ * publications. This way, we can at least show a thumbnail to a user
+ * if they previously generated one via timestamp.
+ */
+const WorkaroundThumbnailGenerator: React.FC<{
+  track: Track,
+}> = ({ track }) => {
+  const dispatch = useAppDispatch();
+
+  const ref = useRef<ReactPlayer>(null);
+  const [ready, setReady] = useState(false);
+  const [seeked, setSeeked] = useState(false);
+
+  useEffect(() => {
+    if (ref.current && ready && track && track.thumbnailTime && !track.thumbnailUri) {
+      ref.current.seekTo(parseFloat(track.thumbnailTime), "seconds");
+    }
+  }, [dispatch, ready, track]);
+
+  useEffect(() => {
+    if (seeked) {
+      const videoElement = ref.current?.getInternalPlayer() as HTMLVideoElement;
+      const canvas = document.createElement("canvas");
+      canvas.width = videoElement.videoWidth;
+      canvas.height = videoElement.videoHeight;
+      const canvasContext = canvas.getContext("2d");
+      if (canvasContext !== null) {
+        canvasContext.drawImage(videoElement, 0, 0);
+        const uri = canvas.toDataURL("image/png");
+
+        if (uri) {
+          dispatch(setThumbnail({ id: track.id, uri: uri }));
+        }
+      }
+    }
+  }, [dispatch, seeked, track]);
+
+  const playerStyle = css({
+    display: "none",
+  });
+
+  return (
+    <ReactPlayer url={track.uri}
+      css={playerStyle}
+      ref={ref}
+      width="unset"
+      height="100%"
+      playing={false}
+      onReady={() => setReady(true)}
+      onSeek={() => setSeeked(true)}
+    />
   );
 };
 

--- a/src/main/ThumbnailSelect.tsx
+++ b/src/main/ThumbnailSelect.tsx
@@ -346,13 +346,10 @@ export const UseForAllTracksButton: React.FC<{
   const tracks = useAppSelector(selectTracks);
 
   // Set the given thumbnail for all tracks
-  const setForOtherThumbnails = (uri: string | undefined) => {
-    if (uri === undefined) {
-      return;
-    }
+  const setForOtherThumbnails = ({ uri, time }: {uri: string | undefined, time: string | undefined}) => {
     const thumbnails = [];
     for (const track of tracks) {
-      thumbnails.push({ id: track.id, uri: uri });
+      thumbnails.push({ id: track.id, uri, time });
     }
     dispatch(setThumbnails(thumbnails));
     dispatch(setHasChanges(true));
@@ -360,7 +357,7 @@ export const UseForAllTracksButton: React.FC<{
 
   return (
     <ThumbnailButton
-      handler={() => { setForOtherThumbnails(track.thumbnailUri); }}
+      handler={() => { setForOtherThumbnails({uri: track.thumbnailUri, time: track.thumbnailTime }); }}
       text={t("thumbnail.buttonUseForOtherThumbnails")}
       tooltipText={t("thumbnail.buttonUseForOtherThumbnails-tooltip")}
       ariaLabel={t("thumbnail.buttonUseForOtherThumbnails-tooltip-aria")}

--- a/src/main/ThumbnailSelect.tsx
+++ b/src/main/ThumbnailSelect.tsx
@@ -315,8 +315,13 @@ export const DiscardButton: React.FC<{
 
   const originalThumbnails = useAppSelector(selectOriginalThumbnails);
 
+  const originalThumbnail = originalThumbnails.find(e => e.id === track.id);
+  const active = (track.thumbnailUri && track.thumbnailUri.startsWith("data") && !track.thumbnailTime)
+    || (track.thumbnailTime && originalThumbnail && track.thumbnailTime != originalThumbnail.time);
+
   const discardThumbnail = (id: string) => {
-    dispatch(setThumbnail({ id: id, uri: originalThumbnails.find(e => e.id === id)?.uri }));
+    dispatch(setThumbnail({ id: id, uri: originalThumbnail?.uri }));
+    dispatch(setThumbnailTime({ id: id, time: originalThumbnail?.time }));
   };
 
   return (
@@ -326,7 +331,7 @@ export const DiscardButton: React.FC<{
       tooltipText={t("thumbnail.buttonDiscard-tooltip")}
       ariaLabel={t("thumbnail.buttonDiscard-tooltip-aria")}
       Icon={LuCircleX}
-      active={(track.thumbnailUri && track.thumbnailUri.startsWith("data") ? true : false)}
+      active={(active ? true : false)}
       index={index}
       overwriteCSS={overwriteCSS}
     />
@@ -357,7 +362,7 @@ export const UseForAllTracksButton: React.FC<{
 
   return (
     <ThumbnailButton
-      handler={() => { setForOtherThumbnails({uri: track.thumbnailUri, time: track.thumbnailTime }); }}
+      handler={() => { setForOtherThumbnails({ uri: track.thumbnailUri, time: track.thumbnailTime }); }}
       text={t("thumbnail.buttonUseForOtherThumbnails")}
       tooltipText={t("thumbnail.buttonUseForOtherThumbnails-tooltip")}
       ariaLabel={t("thumbnail.buttonUseForOtherThumbnails-tooltip-aria")}
@@ -478,7 +483,8 @@ const WorkaroundThumbnailGenerator: React.FC<{
   }, [dispatch, ready, track]);
 
   useEffect(() => {
-    if (seeked) {
+    if (ref.current && ready && track && track.thumbnailTime && !track.thumbnailUri
+      && seeked) {
       const videoElement = ref.current?.getInternalPlayer() as HTMLVideoElement;
       const canvas = document.createElement("canvas");
       canvas.width = videoElement.videoWidth;
@@ -493,7 +499,7 @@ const WorkaroundThumbnailGenerator: React.FC<{
         }
       }
     }
-  }, [dispatch, seeked, track]);
+  }, [dispatch, ready, seeked, track]);
 
   const playerStyle = css({
     display: "none",

--- a/src/main/ThumbnailSelect.tsx
+++ b/src/main/ThumbnailSelect.tsx
@@ -351,7 +351,10 @@ export const UseForAllTracksButton: React.FC<{
   const tracks = useAppSelector(selectTracks);
 
   // Set the given thumbnail for all tracks
-  const setForOtherThumbnails = ({ uri, time }: {uri: string | undefined, time: string | undefined}) => {
+  const setForOtherThumbnails = ({ uri, time }: {
+    uri: string | undefined,
+    time?: { time: string; flavorType: string }
+  }) => {
     const thumbnails = [];
     for (const track of tracks) {
       thumbnails.push({ id: track.id, uri, time });
@@ -472,13 +475,19 @@ const WorkaroundThumbnailGenerator: React.FC<{
 }> = ({ track }) => {
   const dispatch = useAppDispatch();
 
+  const tracks = useAppSelector(selectTracks);
+  const thumbnailTime = track.thumbnailTime;
+  const thumbnailTrack = thumbnailTime
+    ? tracks.find(t => t.flavor.type === thumbnailTime.flavorType)
+    : undefined;
+
   const ref = useRef<ReactPlayer>(null);
   const [ready, setReady] = useState(false);
   const [seeked, setSeeked] = useState(false);
 
   useEffect(() => {
     if (ref.current && ready && track && track.thumbnailTime && !track.thumbnailUri) {
-      ref.current.seekTo(parseFloat(track.thumbnailTime), "seconds");
+      ref.current.seekTo(parseFloat(track.thumbnailTime.time), "seconds");
     }
   }, [dispatch, ready, track]);
 
@@ -505,8 +514,12 @@ const WorkaroundThumbnailGenerator: React.FC<{
     display: "none",
   });
 
+  if (!thumbnailTrack) {
+    return null;
+  }
+
   return (
-    <ReactPlayer url={track.uri}
+    <ReactPlayer url={thumbnailTrack.uri}
       css={playerStyle}
       ref={ref}
       width="unset"

--- a/src/main/ThumbnailSelect.tsx
+++ b/src/main/ThumbnailSelect.tsx
@@ -481,20 +481,20 @@ const WorkaroundThumbnailGenerator: React.FC<{
     ? tracks.find(t => t.flavor.type === thumbnailTime.flavorType)
     : undefined;
 
-  const ref = useRef<ReactPlayer>(null);
+  const ref = useRef<HTMLVideoElement>(null);
   const [ready, setReady] = useState(false);
   const [seeked, setSeeked] = useState(false);
 
   useEffect(() => {
     if (ref.current && ready && track && track.thumbnailTime && !track.thumbnailUri) {
-      ref.current.seekTo(parseFloat(track.thumbnailTime.time), "seconds");
+      ref.current.currentTime = parseFloat(track.thumbnailTime.time);
     }
   }, [dispatch, ready, track]);
 
   useEffect(() => {
     if (ref.current && ready && track && track.thumbnailTime && !track.thumbnailUri
       && seeked) {
-      const videoElement = ref.current?.getInternalPlayer() as HTMLVideoElement;
+      const videoElement = ref.current as HTMLVideoElement;
       const canvas = document.createElement("canvas");
       canvas.width = videoElement.videoWidth;
       canvas.height = videoElement.videoHeight;
@@ -519,14 +519,14 @@ const WorkaroundThumbnailGenerator: React.FC<{
   }
 
   return (
-    <ReactPlayer url={thumbnailTrack.uri}
+    <ReactPlayer src={thumbnailTrack.uri}
       css={playerStyle}
       ref={ref}
       width="unset"
       height="100%"
       playing={false}
       onReady={() => setReady(true)}
-      onSeek={() => setSeeked(true)}
+      onSeeked={() => setSeeked(true)}
     />
   );
 };

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -115,6 +115,7 @@ const VideoPlayers: React.FC<{
 export interface VideoPlayerForwardRef {
   captureVideo: () => string | undefined,
   getWidth: () => number,
+  getCurrentTime: () => number,
 }
 
 interface VideoPlayerProps {
@@ -391,6 +392,9 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
       },
       getWidth() {
         return ref.current?.clientWidth ?? 0;
+      },
+      getCurrentTime() {
+        return (ref.current?.getInternalPlayer() as HTMLVideoElement).currentTime;
       },
     }));
 

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -116,6 +116,7 @@ const VideoPlayers: React.FC<{
 export interface VideoPlayerForwardRef {
   captureVideo: () => string | undefined,
   getWidth: () => number,
+  getCurrentTime: () => number,
 }
 
 interface VideoPlayerProps {
@@ -389,6 +390,9 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
       },
       getWidth() {
         return (ref.current?.getInternalPlayer() as HTMLVideoElement).clientWidth;
+      },
+      getCurrentTime() {
+        return (ref.current?.getInternalPlayer() as HTMLVideoElement).currentTime;
       },
     }));
 

--- a/src/main/VideoPlayers.tsx
+++ b/src/main/VideoPlayers.tsx
@@ -394,7 +394,7 @@ export const VideoPlayer = React.forwardRef<VideoPlayerForwardRef, VideoPlayerPr
         return ref.current?.clientWidth ?? 0;
       },
       getCurrentTime() {
-        return (ref.current?.getInternalPlayer() as HTMLVideoElement).currentTime;
+        return (ref.current as HTMLVideoElement).currentTime;
       },
     }));
 

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -238,6 +238,9 @@ const videoSlice = createSlice({
         setThumbnailHelper(state, element.id, element.uri);
       }
     },
+    setThumbnailTime: (state, action: PayloadAction<{ id: Track["id"], time: Track["thumbnailTime"]; }>) => {
+      setThumbnailTimeHelper(state, action.payload.id, action.payload.time);
+    },
     removeThumbnail: (state, action: PayloadAction<string>) => {
       const index = state.tracks.findIndex(t => t.id === action.payload);
       state.tracks[index].thumbnailUri = undefined;
@@ -573,6 +576,13 @@ const setThumbnailHelper = (state: video, id: Track["id"], uri: Track["thumbnail
   }
 };
 
+const setThumbnailTimeHelper = (state: video, id: Track["id"], time: Track["thumbnailTime"]) => {
+  const index = state.tracks.findIndex(t => t.id === id);
+  if (index >= 0) {
+    state.tracks[index].thumbnailTime = time;
+  }
+};
+
 export const {
   addSegment,
   cut,
@@ -603,6 +613,7 @@ export const {
   setSelectedWorkflowIndex,
   setThumbnail,
   setThumbnails,
+  setThumbnailTime,
   setVideoEnabled,
   setVolume,
   setWaveformImages,

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -233,9 +233,14 @@ const videoSlice = createSlice({
     setThumbnail: (state, action: PayloadAction<{ id: Track["id"], uri: Track["thumbnailUri"]; }>) => {
       setThumbnailHelper(state, action.payload.id, action.payload.uri);
     },
-    setThumbnails: (state, action: PayloadAction<{ id: Track["id"], uri: Track["thumbnailUri"]; }[]>) => {
+    setThumbnails: (state, action: PayloadAction<{ 
+      id: Track["id"],
+      uri: Track["thumbnailUri"],
+      time: Track["thumbnailTime"];
+    }[]>) => {
       for (const element of action.payload) {
         setThumbnailHelper(state, element.id, element.uri);
+        setThumbnailTimeHelper(state, element.id, element.time);
       }
     },
     setThumbnailTime: (state, action: PayloadAction<{ id: Track["id"], time: Track["thumbnailTime"]; }>) => {

--- a/src/redux/videoSlice.ts
+++ b/src/redux/videoSlice.ts
@@ -27,7 +27,7 @@ export interface video {
   hasChanges: boolean,            // Did user make changes in cutting view since last save
   timelineZoom: number,           // Zoom multiplicator for the timeline,
   waveformImages: string[];
-  originalThumbnails: { id: Track["id"], uri: Track["thumbnailUri"]; }[];
+  originalThumbnails: { id: Track["id"], uri: Track["thumbnailUri"], time: Track["thumbnailTime"]; }[];
 
   videoURLs: string[],  // Links to each video
   videoCount: number,   // Total number of videos
@@ -233,7 +233,7 @@ const videoSlice = createSlice({
     setThumbnail: (state, action: PayloadAction<{ id: Track["id"], uri: Track["thumbnailUri"]; }>) => {
       setThumbnailHelper(state, action.payload.id, action.payload.uri);
     },
-    setThumbnails: (state, action: PayloadAction<{ 
+    setThumbnails: (state, action: PayloadAction<{
       id: Track["id"],
       uri: Track["thumbnailUri"],
       time: Track["thumbnailTime"];
@@ -385,7 +385,7 @@ const videoSlice = createSlice({
           return waveformURI;
         }) : state.waveformImages;
         state.originalThumbnails = state.tracks.map(
-          (track: Track) => { return { id: track.id, uri: track.thumbnailUri }; },
+          (track: Track) => { return { id: track.id, uri: track.thumbnailUri, time: track.thumbnailTime }; },
         );
 
         state.lockingActive = payload.locking_active;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,10 @@ export interface Track {
   video_stream: {available: boolean, enabled: boolean, thumbnail_uri: string},
   thumbnailUri: string | undefined,
   thumbnailPriority: number,
-  thumbnailTime?: string,
+  thumbnailTime?: {
+    time: string,
+    flavorType: string,
+  },
 }
 
 export interface Flavor {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export interface Track {
   video_stream: {available: boolean, enabled: boolean, thumbnail_uri: string},
   thumbnailUri: string | undefined,
   thumbnailPriority: number,
+  thumbnailTime?: string,
 }
 
 export interface Flavor {


### PR DESCRIPTION
**THIS PR WILL BREAK THUMBNAIL GENERATION WITHOUT THE RELATED BACKEND PR: https://github.com/opencast/opencast/pull/7698**

Fixes #814.

Currently when generating a thumbnail, we create it here in the frontend and then send it to the backend. With this patch, we instead send the time stamp it was generated from to the backend.

The goal is to let the backend generate the actual thumbnail, instead of the frontend. This avoids quality issues when generating thumbnails from low resolution videos in the frontend. It also allows for respecting institution specific thumbnail settings (e.g. encoding profiles).

The downside is that this relies on workflow properties. As such, admins will have to adapt their workflows or thumbnail generation will be broken for them.

This change should not impact the user experience of using the editor frontend.

### How to test this

Requires changes in the backend. Can otherwise be tested as is.