### PR TITLE
Final GHA polish

### DIFF
--- a/.github/workflows/pr-build-test-branch.yml
+++ b/.github/workflows/pr-build-test-branch.yml
@@ -67,8 +67,20 @@ jobs:
       - name: Upload build to GHA
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.run_id }}
+          name: ${{ github.run_id }}-build
           path: ${{ runner.temp }}/build.tar
+
+            # This is stupid, but GHA currently zeros out the pull_requests list in forked repos
+      # so we have no way to get at this number without going through PRs and matching via hash
+      - name: Save PR Number to disk
+        if: github.event.workflow_run.event == 'pull_request'
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
+      - uses: actions/upload-artifact@v4
+        if: github.event.workflow_run.event == 'pull_request'
+        with:
+          name: ${{ github.run_id }}-number
+          path: pr_number.txt
 
 
   check-no-modified-translations:

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   deploy-pr:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Prepare git
         run: |

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   deploy-pr:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion != 'skipped' }}
     steps:
       - name: Prepare git
         run: |

--- a/.github/workflows/pr-deploy-test-branch.yml
+++ b/.github/workflows/pr-deploy-test-branch.yml
@@ -42,10 +42,25 @@ jobs:
       - name: Fetch build from GHA
         uses: actions/download-artifact@v4
         with:
-          name: ${{ github.event.workflow_run.id }}
+          name: ${{ github.event.workflow_run.id }}-build
           path: ${{ runner.temp }}/
           github-token: ${{ github.token }}
           run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Store build in the clone
+        run: |
+          tar xf ${{ runner.temp }}/build.tar
+
+      - name: Fetch pr number from GHA
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ github.event.workflow_run.id }}-number
+          github-token: ${{ github.token }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR Number
+        run: |
+          echo "PR_NUMBER=$(cat pr_number.txt)" >> $GITHUB_ENV
 
       - name: Store build in the clone
         run: |
@@ -84,7 +99,7 @@ jobs:
       - name: Add comment with deployment location
         uses: thollander/actions-comment-pull-request@v3
         with:
-          pr-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          pr-number: ${{ env.PR_NUMBER }}
           comment-tag: static-test-deployment
           message: >
             This pull request is deployed at


### PR DESCRIPTION
This PR hopefully finally fixes all of the remaining GHA issues.  Several of these will only take effect once they're merged into  develop , but some affect the branch itself so I'm putting them all here and merging them forward for sanity purposes. 

First, we fixed the communication between the build of the branch and container image, and the deploy of them.  GHA blanks the list of PRs in the  workflow_run  run event when filing PRs between forks for 'security reasons'.        
Second, we only fire the subsequent deploys if the parent is successful.                                            

I don't see any further issues in my fork.  That being said, one of the issues being fixed here is that the behaviour between forks sooo...                                                                                   
