### PR TITLE
Prevent user from making video too short

### DIFF
--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -108,7 +108,8 @@
       "startProcessing-button": "Start processing",
       "back-button": "Take me back",
       "selectWF-button": "Click to select this workflow",
-      "selectWF-button-aria": "Press to select the workflow: {{stateName}}\n"
+      "selectWF-button-aria": "Press to select the workflow: {{stateName}}\n",
+      "error-segmentsTooShort": "The remaining cutting segments are too short. Make sure that at least one segment is at least 2 seconds long. If you are trying to remove the video track, use the track selection menu."
     },
 
     "timeline": {

--- a/src/main/Save.tsx
+++ b/src/main/Save.tsx
@@ -17,7 +17,7 @@ import {
   selectTracks,
   setHasChanges as videoSetHasChanges,
 } from "../redux/videoSlice";
-import { postVideoInformation, selectStatus, selectError } from "../redux/workflowPostSlice";
+import { postVideoInformation, selectStatus, selectError, setPostRequestError } from "../redux/workflowPostSlice";
 
 import { CallbackButton, PageButton } from "./Finish";
 
@@ -39,7 +39,7 @@ import { Spinner } from "@opencast/appkit";
 import { ProtoButton } from "@opencast/appkit";
 import { setEnd } from "../redux/endSlice";
 import { selectSubtitles as selectChapters } from "../redux/chapterSlice";
-import { SubtitlesInEditor } from "../types";
+import { Segment, SubtitlesInEditor } from "../types";
 
 /**
  * Shown if the user wishes to save.
@@ -165,7 +165,23 @@ export const SaveButton: React.FC<{
       deleted,
     }));
 
+  const validateSegmentLength = (segments: Segment[]) => {
+    let okay = false;
+    for (const segment of segments) {
+      if (!segment.deleted && (segment.end - segment.start > 2000)) {
+        okay = true;
+      }
+    }
+    return okay;
+  };
+
   const save = () => {
+    if (!validateSegmentLength(segments)) {
+      dispatch(setPostRequestError(
+        t("workflowSelection.error-segmentsTooShort"),
+      ));
+      return;
+    }
     dispatch(postVideoInformation({
       segments: segments,
       tracks: tracks,

--- a/src/redux/workflowPostSlice.ts
+++ b/src/redux/workflowPostSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { client } from "../util/client";
 import { Segment, PostEditArgument, httpRequestState } from "../types";
 import { settings } from "../config";
@@ -64,6 +64,10 @@ const workflowPostSlice = createSlice({
     resetPostRequestState: state => {
       state.status = "idle";
     },
+    setPostRequestError: (state, action: PayloadAction<httpRequestState["error"]>) => {
+      state.status = "failed";
+      state.error = action.payload;
+    },
   },
   extraReducers: builder => {
     builder.addCase(
@@ -110,7 +114,7 @@ export const convertSegments = (segments: Segment[]) => {
   return newSegments;
 };
 
-export const { resetPostRequestState } = workflowPostSlice.actions;
+export const { resetPostRequestState, setPostRequestError } = workflowPostSlice.actions;
 
 export const { selectStatus, selectError } = workflowPostSlice.selectors;
 


### PR DESCRIPTION
Helps with https://github.com/opencast/opencast/issues/5174.

The backend will throw an error during the workflow if all segments in the cutting view are set to "delete", or if the non-deleted segments are all shorter than 2 seconds. This adds a check that prevents a user from sending such an "illegal" segment list to the backend.