### PR TITLE
Subtitle timeline consolidation

### DIFF
--- a/src/main/CuttingActions.tsx
+++ b/src/main/CuttingActions.tsx
@@ -393,7 +393,7 @@ interface ZoomSliderInterface {
   ariaLabelText: string,
 }
 
-const ZoomSlider : React.FC<ZoomSliderInterface> = ({
+export const ZoomSlider : React.FC<ZoomSliderInterface> = ({
   actionHandler,
   tooltip,
   ariaLabelText,
@@ -462,7 +462,7 @@ const ZoomSlider : React.FC<ZoomSliderInterface> = ({
   );
 };
 
-const ZoomDropdown : React.FC = () => {
+export const ZoomDropdown : React.FC = () => {
   const theme = useTheme();
   const dispatch = useAppDispatch();
   const seconds = useAppSelector(selectDisplayDuration);

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
 import { SegmentsList as CuttingSegmentsList, Waveforms } from "./Timeline";
+import { ZoomDropdown, ZoomSlider } from "./CuttingActions";
 import {
   addCueAtIndex,
   selectCurrentlyAt,
   selectSelectedSubtitleById,
   selectSelectedSubtitleId,
-  setClickTriggered,
   setCueAtIndex,
   setCurrentlyAt,
   setFocusSegmentId,
@@ -14,20 +14,29 @@ import {
   setFocusSegmentTriggered2,
 } from "../redux/subtitleSlice";
 import { useAppDispatch, useAppSelector } from "../redux/store";
-import { moveCut, selectActiveSegmentIndex, selectDuration, selectSegments } from "../redux/videoSlice";
+import {
+  moveCut,
+  selectActiveSegmentIndex,
+  selectDisplayDuration,
+  selectDuration,
+  selectSegments,
+  timelineZoomIn,
+  timelineZoomOut,
+} from "../redux/videoSlice";
 import Draggable, { DraggableEventHandler } from "react-draggable";
 import { SubtitleCue } from "../types";
 import { Resizable, ResizeCallbackData } from "react-resizable";
 import "react-resizable/css/styles.css";
 import ScrollContainer, { ScrollEvent } from "react-indiana-drag-scroll";
 import { useTheme } from "../themes";
-import { ThemedTooltip } from "./Tooltip";
 import { useTranslation } from "react-i18next";
 import { useHotkeys } from "react-hotkeys-hook";
 import { shallowEqual } from "react-redux";
 import TimelineStamps from "./TimelineStamps";
+import { rewriteKeys } from "../globalKeys";
 import { selectKeymap } from "../redux/hotkeySlice";
 import { useResizeObserver } from "usehooks-ts";
+import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/toolkit";
 
 /**
  * Copy-paste of the timeline in Video.tsx, so that we can make some small adjustments,
@@ -44,15 +53,42 @@ const SubtitleTimeline: React.FC = () => {
   const duration = useAppSelector(selectDuration);
   const currentlyAt = useAppSelector(selectCurrentlyAt);
   const subtitleId = useAppSelector(selectSelectedSubtitleId, shallowEqual);
+  const displayDuration = useAppSelector(selectDisplayDuration);
 
   const ref = useRef<HTMLDivElement>(null);
   const { width = 1 } = useResizeObserver<HTMLDivElement>({ ref: ref as React.RefObject<HTMLDivElement> });
   const refTop = useRef<HTMLElement>(null);
-  const refMini = useRef<HTMLDivElement>(null);
-  const { width: widthMiniTimeline = 1 } = useResizeObserver({ ref: refMini as React.RefObject<HTMLDivElement> });
 
-  // How much of the timeline should be visible in milliseconds. Aka a specific zoom level
-  const timelineCutoutInMs = 10000;
+  // How much of the timeline should be visible in milliseconds. Driven by the shared timeline zoom level
+  const timelineCutoutInMs = displayDuration * 1000;
+
+  // Callback for the zoom slider/dropdown, dispatching the zoom action to redux
+  const dispatchZoomAction = (
+    action: ActionCreatorWithoutPayload<string> | undefined,
+    actionWithPayload: ActionCreatorWithPayload<number, string> | undefined,
+    payload: number,
+  ) => {
+    if (action) {
+      dispatch(action());
+    }
+    if (actionWithPayload) {
+      dispatch(actionWithPayload(payload));
+    }
+  };
+
+  // Hotkeys for zooming, shared with the Cutting/Chapter timelines
+  useHotkeys(
+    keymap.cutting.zoomIn.key,
+    () => dispatch(timelineZoomIn()),
+    keymap.cutting.zoomIn.options,
+    [],
+  );
+  useHotkeys(
+    keymap.cutting.zoomOut.key,
+    () => dispatch(timelineZoomOut()),
+    keymap.cutting.zoomOut.options,
+    [],
+  );
 
   const timelineStyle = css({
     position: "relative",     // Need to set position for Draggable bounds to work
@@ -66,13 +102,6 @@ const SubtitleTimeline: React.FC = () => {
   const [visibleWidth, setVisibleWidth] = useState(0);
   const paddingOffset = visibleWidth / 2;
   const virtualScrollLeft = scrollLeft - paddingOffset;
-
-  const setCurrentlyAtToClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const offsetX = e.clientX - rect.left;
-    dispatch(setClickTriggered(true));
-    dispatch(setCurrentlyAt((offsetX / widthMiniTimeline) * (duration)));
-  };
 
   // Make sure visibleWidth is set so canvas is drawn on first render
   useLayoutEffect(() => {
@@ -189,13 +218,14 @@ const SubtitleTimeline: React.FC = () => {
         height={20}
       />
       {/* Scrollable timeline container. Has width of parent*/}
-      <ScrollContainer innerRef={refTop} css={{ overflow: "hidden", width: "100%", height: "215px" }}
+      <ScrollContainer innerRef={refTop} css={{ overflowY: "hidden", width: "100%", height: "215px" }}
         vertical={false}
         horizontal={true}
         onEndScroll={onEndScroll}
         onScroll={updateScrollMetrics}
         // dom elements with this id in the container will not trigger scrolling when dragged
         ignoreElements={".prevent-drag-scroll"}
+        hideScrollbars={false}            // ScrollContainer hides scrollbars per default
       >
         {/* Container. Overflows. Width based on parent times zoom level*/}
         <div ref={ref} css={timelineStyle}>
@@ -214,32 +244,19 @@ const SubtitleTimeline: React.FC = () => {
           </div>
         </div>
       </ScrollContainer>
-      {/* Mini Timeline. Makes it easier to understand position in scrollable timeline */}
-      <ThemedTooltip title={t("subtitleTimeline.overviewTimelineTooltip")}>
-        <div
-          onMouseDown={e => setCurrentlyAtToClick(e)}
-          css={{
-            position: "relative",
-            width: "100%",
-            height: "15px",
-            background: `linear-gradient(to right, grey ${(currentlyAt / duration) * 100}%,
-              lightgrey ${(currentlyAt / duration) * 100}%)`,
-            borderRadius: "3px",
-          }}
-          ref={refMini}
-        >
-          <div
-            css={{
-              position: "absolute",
-              width: "2px",
-              height: "100%",
-              left: (currentlyAt / duration) * (widthMiniTimeline),
-              top: 0,
-              background: "black",
-            }}
-          />
-        </div>
-      </ThemedTooltip>
+      <div css={{ display: "flex", flexDirection: "row", justifyContent: "center", alignItems: "center", gap: "10px" }}>
+        <ZoomSlider actionHandler={dispatchZoomAction}
+          tooltip={t("cuttingActions.zoomSlider-tooltip", {
+            hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn.key),
+            hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut.key),
+          })}
+          ariaLabelText={t("cuttingActions.zoomSlider-aria", {
+            hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn.key),
+            hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut.key),
+          })}
+        />
+        <ZoomDropdown />
+      </div>
     </div>
 
 

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
-import { SegmentsList as CuttingSegmentsList, Scrubber, Waveforms } from "./Timeline";
+import { SegmentsList as CuttingSegmentsList, Scrubber, Waveforms, useZoomableTimeline } from "./Timeline";
 import { ZoomDropdown, ZoomSlider } from "./CuttingActions";
 import {
   addCueAtIndex,
@@ -20,11 +20,8 @@ import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
   moveCut,
   selectActiveSegmentIndex,
-  selectDisplayDuration,
   selectDuration,
-  selectDurationInSeconds,
   selectSegments,
-  selectTimelineZoom,
   timelineZoomIn,
   timelineZoomOut,
 } from "../redux/videoSlice";
@@ -40,7 +37,6 @@ import { shallowEqual } from "react-redux";
 import TimelineStamps from "./TimelineStamps";
 import { rewriteKeys } from "../globalKeys";
 import { selectKeymap } from "../redux/hotkeySlice";
-import { useResizeObserver } from "usehooks-ts";
 import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/toolkit";
 
 /**
@@ -54,12 +50,8 @@ const SubtitleTimeline: React.FC = () => {
   // Init redux variables
   const dispatch = useAppDispatch();
   const keymap = useAppSelector(selectKeymap);
-  const duration = useAppSelector(selectDuration);
-  const durationInSeconds = useAppSelector(selectDurationInSeconds);
   const currentlyAt = useAppSelector(selectCurrentlyAt);
   const subtitleId = useAppSelector(selectSelectedSubtitleId, shallowEqual);
-  const displayDuration = useAppSelector(selectDisplayDuration);
-  const timelineZoom = useAppSelector(selectTimelineZoom);
 
   // Height of the time codes ruler that overlays the top of the scrollable timeline area
   const timelineStampsHeight = 20;
@@ -70,15 +62,11 @@ const SubtitleTimeline: React.FC = () => {
   const timelineHeight = timelineStampsHeight + subtitleSegmentsHeight + waveformHeight;
 
   const scrubberRef = useRef<HTMLDivElement | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
-  const { width = 1 } = useResizeObserver<HTMLDivElement>({ ref: ref as React.RefObject<HTMLDivElement> });
-  const scrollContainerRef = useRef<HTMLElement>(null);
-  const { width: scrollContainerWidth = 1 } = useResizeObserver({
-    ref: scrollContainerRef as React.RefObject<HTMLElement>,
-  });
-
-  const currentlyScrolling = useRef(false);
-  const zoomCenter = useRef(0);
+  const {
+    duration, ref, width, scrollContainerRef, scrollContainerWidth,
+    scrollLeft, visibleWidth, zoomedWidth,
+    updateScrollMetrics, updateScroll, setCurrentlyAtToClick, scrollByOwnWidth,
+  } = useZoomableTimeline(currentlyAt, setClickTriggered, setCurrentlyAt);
 
   // Callback for the zoom slider/dropdown, dispatching the zoom action to redux
   const dispatchZoomAction = (
@@ -108,79 +96,11 @@ const SubtitleTimeline: React.FC = () => {
     [],
   );
 
-  // Vars for timelineStamps
-  const [scrollLeft, setScrollLeft] = useState(0);
-  const [visibleWidth, setVisibleWidth] = useState(0);
-
-  // Keep track of what point of the timeline should stay in view when the zoom level changes
-  const updateScroll = () => {
-    if (currentlyScrolling.current) {
-      currentlyScrolling.current = false;
-      return;
-    }
-    const scrollLeft = scrollContainerRef.current?.scrollLeft ?? 0;
-    const clientWidth = scrollContainerRef.current?.clientWidth ?? 0;
-    const centerPosition = scrollLeft + 0.5 * clientWidth;
-    const scrubberPosition = duration ? (currentlyAt / duration) * width : 0;
-    const scrubberVisible = scrollLeft <= scrubberPosition && scrubberPosition <= scrollLeft + clientWidth;
-
-    zoomCenter.current = (scrubberVisible ? scrubberPosition : centerPosition) / width;
-  };
-
-  const updateScrollMetrics = () => {
-    if (!scrollContainerRef.current) {
-      return;
-    }
-    const el = scrollContainerRef.current;
-    setScrollLeft(el.scrollLeft);
-    setVisibleWidth(el.clientWidth);
-  };
-
-  const displayPercentage = (durationInSeconds / displayDuration);
-  const zoomedWidth = scrollContainerWidth * displayPercentage;
-
-  // Make sure visibleWidth is set so canvas is drawn on first render
-  useLayoutEffect(() => {
-    updateScrollMetrics();
-  }, [width, duration]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(updateScroll, [currentlyAt, timelineZoom, width, scrollContainerWidth]);
-
-  // Keep the previously visible point of the timeline in view when the zoom level changes
-  useEffect(() => {
-    if (!scrollContainerRef.current) {
-      return;
-    }
-    const clientWidth = scrollContainerRef.current.clientWidth ?? 0;
-    const left = zoomCenter.current * displayPercentage * clientWidth - 0.5 * clientWidth;
-
-    currentlyScrolling.current = true;
-    scrollContainerRef.current.scrollLeft = left;
-  }, [displayPercentage]);
-
   const timelineStyle = css({
     position: "relative",     // Need to set position for Draggable bounds to work
     height: timelineHeight + "px",
     width: `${zoomedWidth}px`,    // Width modified by zoom
   });
-
-  // Update the current time based on the position clicked on the timeline
-  const setCurrentlyAtToClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const offsetX = e.clientX - rect.left;
-    dispatch(setClickTriggered(true));
-    dispatch(setCurrentlyAt((offsetX / width) * (duration)));
-  };
-
-  // Scroll the scroll container by its width one time
-  // To be used when the scrubber moves out of sight while playing the video.
-  const scrollByOwnWidth = () => {
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.scrollLeft = scrollContainerRef.current?.scrollLeft + scrollContainerWidth;
-      updateScroll();
-    }
-  };
 
   // Callback for adding subtitle segment by hotkey
   const addCue = (time: number) => {

--- a/src/main/SubtitleTimeline.tsx
+++ b/src/main/SubtitleTimeline.tsx
@@ -1,17 +1,20 @@
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { css } from "@emotion/react";
-import { SegmentsList as CuttingSegmentsList, Waveforms } from "./Timeline";
+import { SegmentsList as CuttingSegmentsList, Scrubber, Waveforms } from "./Timeline";
 import { ZoomDropdown, ZoomSlider } from "./CuttingActions";
 import {
   addCueAtIndex,
   selectCurrentlyAt,
+  selectIsPlaying,
   selectSelectedSubtitleById,
   selectSelectedSubtitleId,
+  setClickTriggered,
   setCueAtIndex,
   setCurrentlyAt,
   setFocusSegmentId,
   setFocusSegmentTriggered,
   setFocusSegmentTriggered2,
+  setIsPlaying,
 } from "../redux/subtitleSlice";
 import { useAppDispatch, useAppSelector } from "../redux/store";
 import {
@@ -19,7 +22,9 @@ import {
   selectActiveSegmentIndex,
   selectDisplayDuration,
   selectDuration,
+  selectDurationInSeconds,
   selectSegments,
+  selectTimelineZoom,
   timelineZoomIn,
   timelineZoomOut,
 } from "../redux/videoSlice";
@@ -45,22 +50,35 @@ import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/
 const SubtitleTimeline: React.FC = () => {
 
   const { t } = useTranslation();
-  const theme = useTheme();
 
   // Init redux variables
   const dispatch = useAppDispatch();
   const keymap = useAppSelector(selectKeymap);
   const duration = useAppSelector(selectDuration);
+  const durationInSeconds = useAppSelector(selectDurationInSeconds);
   const currentlyAt = useAppSelector(selectCurrentlyAt);
   const subtitleId = useAppSelector(selectSelectedSubtitleId, shallowEqual);
   const displayDuration = useAppSelector(selectDisplayDuration);
+  const timelineZoom = useAppSelector(selectTimelineZoom);
 
+  // Height of the time codes ruler that overlays the top of the scrollable timeline area
+  const timelineStampsHeight = 20;
+  // Height of the subtitle segments row and of the waveform below it
+  const subtitleSegmentsHeight = 80;
+  const waveformHeight = 120;
+  // Height of the scrollable timeline area. Also used to size the scrubber
+  const timelineHeight = timelineStampsHeight + subtitleSegmentsHeight + waveformHeight;
+
+  const scrubberRef = useRef<HTMLDivElement | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const { width = 1 } = useResizeObserver<HTMLDivElement>({ ref: ref as React.RefObject<HTMLDivElement> });
-  const refTop = useRef<HTMLElement>(null);
+  const scrollContainerRef = useRef<HTMLElement>(null);
+  const { width: scrollContainerWidth = 1 } = useResizeObserver({
+    ref: scrollContainerRef as React.RefObject<HTMLElement>,
+  });
 
-  // How much of the timeline should be visible in milliseconds. Driven by the shared timeline zoom level
-  const timelineCutoutInMs = displayDuration * 1000;
+  const currentlyScrolling = useRef(false);
+  const zoomCenter = useRef(0);
 
   // Callback for the zoom slider/dropdown, dispatching the zoom action to redux
   const dispatchZoomAction = (
@@ -90,33 +108,79 @@ const SubtitleTimeline: React.FC = () => {
     [],
   );
 
-  const timelineStyle = css({
-    position: "relative",     // Need to set position for Draggable bounds to work
-    width: ((duration / timelineCutoutInMs)) * 100 + "%",    // Total length of timeline based on number of cutouts
-    paddingLeft: "50%",
-    paddingRight: "50%",
-  });
-
   // Vars for timelineStamps
   const [scrollLeft, setScrollLeft] = useState(0);
   const [visibleWidth, setVisibleWidth] = useState(0);
-  const paddingOffset = visibleWidth / 2;
-  const virtualScrollLeft = scrollLeft - paddingOffset;
+
+  // Keep track of what point of the timeline should stay in view when the zoom level changes
+  const updateScroll = () => {
+    if (currentlyScrolling.current) {
+      currentlyScrolling.current = false;
+      return;
+    }
+    const scrollLeft = scrollContainerRef.current?.scrollLeft ?? 0;
+    const clientWidth = scrollContainerRef.current?.clientWidth ?? 0;
+    const centerPosition = scrollLeft + 0.5 * clientWidth;
+    const scrubberPosition = duration ? (currentlyAt / duration) * width : 0;
+    const scrubberVisible = scrollLeft <= scrubberPosition && scrubberPosition <= scrollLeft + clientWidth;
+
+    zoomCenter.current = (scrubberVisible ? scrubberPosition : centerPosition) / width;
+  };
+
+  const updateScrollMetrics = () => {
+    if (!scrollContainerRef.current) {
+      return;
+    }
+    const el = scrollContainerRef.current;
+    setScrollLeft(el.scrollLeft);
+    setVisibleWidth(el.clientWidth);
+  };
+
+  const displayPercentage = (durationInSeconds / displayDuration);
+  const zoomedWidth = scrollContainerWidth * displayPercentage;
 
   // Make sure visibleWidth is set so canvas is drawn on first render
   useLayoutEffect(() => {
     updateScrollMetrics();
   }, [width, duration]);
 
-  // Apply horizonal scrolling when scrolled from somewhere else
-  useEffect(() => {
-    if (currentlyAt !== undefined && refTop.current) {
-      const scrollLeftMax = (refTop.current.scrollWidth - refTop.current.clientWidth);
-      refTop.current.scrollTo(Math.round((currentlyAt / duration) * scrollLeftMax), 0);
-    }
-  }, [currentlyAt, duration, width]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(updateScroll, [currentlyAt, timelineZoom, width, scrollContainerWidth]);
 
-  const [keyboardJumpDelta, setKeyboardJumpDelta] = useState(1000);  // In milliseconds. For keyboard navigation
+  // Keep the previously visible point of the timeline in view when the zoom level changes
+  useEffect(() => {
+    if (!scrollContainerRef.current) {
+      return;
+    }
+    const clientWidth = scrollContainerRef.current.clientWidth ?? 0;
+    const left = zoomCenter.current * displayPercentage * clientWidth - 0.5 * clientWidth;
+
+    currentlyScrolling.current = true;
+    scrollContainerRef.current.scrollLeft = left;
+  }, [displayPercentage]);
+
+  const timelineStyle = css({
+    position: "relative",     // Need to set position for Draggable bounds to work
+    height: timelineHeight + "px",
+    width: `${zoomedWidth}px`,    // Width modified by zoom
+  });
+
+  // Update the current time based on the position clicked on the timeline
+  const setCurrentlyAtToClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    dispatch(setClickTriggered(true));
+    dispatch(setCurrentlyAt((offsetX / width) * (duration)));
+  };
+
+  // Scroll the scroll container by its width one time
+  // To be used when the scrubber moves out of sight while playing the video.
+  const scrollByOwnWidth = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollLeft = scrollContainerRef.current?.scrollLeft + scrollContainerWidth;
+      updateScroll();
+    }
+  };
 
   // Callback for adding subtitle segment by hotkey
   const addCue = (time: number) => {
@@ -129,33 +193,6 @@ const SubtitleTimeline: React.FC = () => {
     }));
   };
 
-  // Callbacks for keyboard controls
-  // TODO: Better increases and decreases than ten intervals
-  // TODO: Additional helpful controls (e.g. jump to start/end of segment/next segment)
-  useHotkeys(
-    keymap.timeline.left.key,
-    () => dispatch(setCurrentlyAt(Math.max(currentlyAt - keyboardJumpDelta, 0))),
-    keymap.timeline.left.options,
-    [currentlyAt, keyboardJumpDelta],
-  );
-  useHotkeys(
-    keymap.timeline.right.key,
-    () => dispatch(setCurrentlyAt(Math.min(currentlyAt + keyboardJumpDelta, duration))),
-    keymap.timeline.right.options,
-    [currentlyAt, keyboardJumpDelta, duration],
-  );
-  useHotkeys(
-    keymap.timeline.increase.key,
-    () => setKeyboardJumpDelta(keyboardJumpDelta => Math.min(keyboardJumpDelta * 10, 1000000)),
-    keymap.timeline.increase.options,
-    [keyboardJumpDelta],
-  );
-  useHotkeys(
-    keymap.timeline.decrease.key,
-    () => setKeyboardJumpDelta(keyboardJumpDelta => Math.max(keyboardJumpDelta / 10, 1)),
-    keymap.timeline.decrease.options,
-    [keyboardJumpDelta],
-  );
   useHotkeys(
     keymap.subtitleList.addCue.key,
     () => addCue(currentlyAt),
@@ -163,25 +200,13 @@ const SubtitleTimeline: React.FC = () => {
     [currentlyAt],
   );
 
-  const updateScrollMetrics = () => {
-    if (!refTop.current) {
-      return;
-    }
-    const el = refTop.current;
-    setScrollLeft(el.scrollLeft);
-    setVisibleWidth(el.clientWidth);
-  };
-
   // Callback for the scroll container
   const onEndScroll = (e: ScrollEvent) => {
-    // If scrolled by user
-    if (!e.external && refTop && refTop.current) {
-      const offsetX = refTop.current.scrollLeft;
-      const scrollLeftMax = (refTop.current.scrollWidth - refTop.current.clientWidth);
-      dispatch(setCurrentlyAt((offsetX / scrollLeftMax) * (duration)));
+    updateScroll();
 
-      // Blur active element after scrolling, to ensure hotkeys are working
-      // This is a little hack to work around focus getting stuck in textarea elements from the subtitle list
+    // Blur active element after scrolling, to ensure hotkeys are working
+    // This is a little hack to work around focus getting stuck in textarea elements from the subtitle list
+    if (!e.external) {
       try {
         (document.activeElement as HTMLElement).blur();
       } catch (_e) {
@@ -198,27 +223,19 @@ const SubtitleTimeline: React.FC = () => {
 
   return (
     <div css={subtitleTimelineStyle}>
-      {/* "Scrubber". Sits smack dab in the middle and does not move */}
-      <div
-        css={{
-          position: "absolute",
-          width: "2px",
-          height: "222px",
-          ...(refTop.current) && { left: (refTop.current.clientWidth / 2) },
-          background: `${theme.text}`,
-          zIndex: 100,
-        }}
-      />
-      {/* Time codes above the timeline */}
-      <TimelineStamps
-        durationMs={duration}
-        zoomedWidth={width}
-        scrollLeft={virtualScrollLeft}
-        visibleWidth={visibleWidth}
-        height={20}
-      />
+      {/* Time codes above the timeline. Overlays the top of the scrollable container, like the scrubber does */}
+      <div css={css({ position: "absolute" })}>
+        <TimelineStamps
+          durationMs={duration}
+          zoomedWidth={zoomedWidth}
+          scrollLeft={scrollLeft}
+          visibleWidth={visibleWidth}
+          height={timelineStampsHeight}
+        />
+      </div>
       {/* Scrollable timeline container. Has width of parent*/}
-      <ScrollContainer innerRef={refTop} css={{ overflowY: "hidden", width: "100%", height: "215px" }}
+      <ScrollContainer innerRef={scrollContainerRef}
+        css={{ overflowY: "hidden", width: "100%", height: `${timelineHeight}px` }}
         vertical={false}
         horizontal={true}
         onEndScroll={onEndScroll}
@@ -228,19 +245,34 @@ const SubtitleTimeline: React.FC = () => {
         hideScrollbars={false}            // ScrollContainer hides scrollbars per default
       >
         {/* Container. Overflows. Width based on parent times zoom level*/}
-        <div ref={ref} css={timelineStyle}>
-          <TimelineSubtitleSegmentsList timelineWidth={width} />
-          <div css={{ position: "relative", height: "100px" }} >
-            <Waveforms timelineHeight={120} />
-            <CuttingSegmentsList
-              timelineWidth={width}
-              timelineHeight={120}
-              styleByActiveSegment={false}
-              tabable={false}
-              selectSegments={selectSegments}
-              selectActiveSegmentIndex={selectActiveSegmentIndex}
-              moveCut={moveCut}
-            />
+        <div ref={ref} css={timelineStyle} onMouseDown={e => setCurrentlyAtToClick(e)}>
+          <Scrubber
+            ref={scrubberRef}
+            timelineWidth={width}
+            timelineHeight={timelineHeight}
+            scrollContainerWidth={scrollContainerWidth}
+            scrollLeft={scrollContainerRef.current?.scrollLeft ?? 0}
+            scrollTheContainerbyOwnWidth={scrollByOwnWidth}
+            selectCurrentlyAt={selectCurrentlyAt}
+            selectIsPlaying={selectIsPlaying}
+            setCurrentlyAt={setCurrentlyAt}
+            setIsPlaying={setIsPlaying}
+          />
+          {/* Pushed down below the time codes, which overlay this content from above */}
+          <div css={{ position: "relative", top: `${timelineStampsHeight}px` }}>
+            <TimelineSubtitleSegmentsList timelineWidth={width} />
+            <div css={{ position: "relative", height: `${waveformHeight}px` }} >
+              <Waveforms timelineHeight={waveformHeight} />
+              <CuttingSegmentsList
+                timelineWidth={width}
+                timelineHeight={waveformHeight}
+                styleByActiveSegment={false}
+                tabable={false}
+                selectSegments={selectSegments}
+                selectActiveSegmentIndex={selectActiveSegmentIndex}
+                moveCut={moveCut}
+              />
+            </div>
           </div>
         </div>
       </ScrollContainer>
@@ -475,6 +507,7 @@ const TimelineSubtitleSegment: React.FC<{
     <Draggable
       onStart={onStartDrag}
       onStop={onStopDrag}
+      onMouseDown={e => e.stopPropagation()}  // Prevent timeline click from also jumping the scrubber here
       defaultPosition={{ x: 10, y: 10 }}
       position={controlledPosition}
       axis="x"

--- a/src/main/ThumbnailGeneration.tsx
+++ b/src/main/ThumbnailGeneration.tsx
@@ -25,6 +25,7 @@ import {
 } from "../redux/videoSlice";
 import { Track } from "../types";
 import Timeline from "./Timeline";
+import { ZoomDropdown, ZoomSlider } from "./CuttingActions";
 import {
   selectIsPlaying,
   selectIsMuted,
@@ -39,6 +40,8 @@ import {
   setCurrentlyAt,
   jumpToPreviousSegment,
   jumpToNextSegment,
+  timelineZoomIn,
+  timelineZoomOut,
 } from "../redux/videoSlice";
 import { ThemedTooltip } from "./Tooltip";
 import { VideoPlayer, VideoPlayerForwardRef } from "./VideoPlayers";
@@ -51,6 +54,10 @@ import {
   UploadButton,
 } from "./ThumbnailSelect";
 import { selectIndex, setIsDisplayEditView } from "../redux/thumbnailSlice";
+import { selectKeymap } from "../redux/hotkeySlice";
+import { useHotkeys } from "react-hotkeys-hook";
+import { rewriteKeys } from "../globalKeys";
+import { ActionCreatorWithoutPayload, ActionCreatorWithPayload } from "@reduxjs/toolkit";
 
 
 /**
@@ -202,6 +209,7 @@ const ThumbnailActions: React.FC<{
 }) => {
   const { t } = useTranslation();
   const dispatch = useAppDispatch();
+  const keymap = useAppSelector(selectKeymap);
   const theme = useTheme();
 
   const primaryTrack = useAppSelector(selectPrimaryThumbnailTrack);
@@ -214,6 +222,34 @@ const ThumbnailActions: React.FC<{
     dispatch(setThumbnail({ id: track.id, uri: uri }));
     dispatch(setHasChanges(true));
   };
+
+  // Callback for the zoom slider/dropdown, dispatching the zoom action to redux
+  const dispatchZoomAction = (
+    action: ActionCreatorWithoutPayload<string> | undefined,
+    actionWithPayload: ActionCreatorWithPayload<number, string> | undefined,
+    payload: number,
+  ) => {
+    if (action) {
+      dispatch(action());
+    }
+    if (actionWithPayload) {
+      dispatch(actionWithPayload(payload));
+    }
+  };
+
+  // Hotkeys for zooming, shared with the Cutting/Chapter/Subtitle timelines
+  useHotkeys(
+    keymap.cutting.zoomIn.key,
+    () => dispatch(timelineZoomIn()),
+    keymap.cutting.zoomIn.options,
+    [],
+  );
+  useHotkeys(
+    keymap.cutting.zoomOut.key,
+    () => dispatch(timelineZoomOut()),
+    keymap.cutting.zoomOut.options,
+    [],
+  );
 
   const thumbnailActionsStyle = css({
     display: "flex",
@@ -269,7 +305,17 @@ const ThumbnailActions: React.FC<{
           <div css={verticalLineStyle} />
         </>
       }
-
+      <ZoomSlider actionHandler={dispatchZoomAction}
+        tooltip={t("cuttingActions.zoomSlider-tooltip", {
+          hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn.key),
+          hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut.key),
+        })}
+        ariaLabelText={t("cuttingActions.zoomSlider-aria", {
+          hotkeyNameIn: rewriteKeys(keymap.cutting.zoomIn.key),
+          hotkeyNameOut: rewriteKeys(keymap.cutting.zoomOut.key),
+        })}
+      />
+      <ZoomDropdown />
     </div>
   );
 };

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -296,13 +296,25 @@ export const Scrubber = React.forwardRef<HTMLDivElement, ScrubberProps>((props, 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [timelineWidth]);
 
-  // Check when the scrubber moves out of sight (can happen when playing the video while zoomed in)
-  // and then scroll the container
+  // Latest scroll metrics, read without making the effect below re-run on every manual scroll
+  const scrollLeftRef = useRef(scrollLeft);
+  const scrollContainerWidthRef = useRef(scrollContainerWidth);
+  const scrollTheContainerbyOwnWidthRef = useRef(scrollTheContainerbyOwnWidth);
   useEffect(() => {
-    if (controlledPosition.x > (scrollLeft + scrollContainerWidth)) {
-      scrollTheContainerbyOwnWidth();
+    scrollLeftRef.current = scrollLeft;
+    scrollContainerWidthRef.current = scrollContainerWidth;
+    scrollTheContainerbyOwnWidthRef.current = scrollTheContainerbyOwnWidth;
+  });
+
+  // Check when the scrubber moves out of sight (can happen when playing the video while zoomed in)
+  // and then scroll the container. Only reacts to the scrubber actually moving, so that manually
+  // scrolling the scrubber out of view (e.g. to look at another part of the timeline) doesn't
+  // immediately get overridden.
+  useEffect(() => {
+    if (controlledPosition.x > (scrollLeftRef.current + scrollContainerWidthRef.current)) {
+      scrollTheContainerbyOwnWidthRef.current();
     }
-  }, [controlledPosition.x, scrollContainerWidth, scrollLeft, scrollTheContainerbyOwnWidth]);
+  }, [controlledPosition.x]);
 
   // Callback for when the scrubber gets dragged by the user
   const onControlledDrag: DraggableEventHandler = debounce((_e, position: { x: number, y : number }) => {

--- a/src/main/Timeline.tsx
+++ b/src/main/Timeline.tsx
@@ -47,6 +47,106 @@ import { selectKeymap } from "../redux/hotkeySlice";
 import { useResizeObserver } from "usehooks-ts";
 
 /**
+ * Bundles the scroll/zoom mechanics shared by every zoomable, horizontally scrollable
+ * timeline (Cutting, Chapters, Subtitles): measuring the visible and total width, keeping
+ * the current view centered on zoom changes, and turning a click into a seek.
+ */
+export const useZoomableTimeline = (
+  currentlyAt: number,
+  setClickTriggered: ActionCreatorWithPayload<boolean, string>,
+  setCurrentlyAt: ActionCreatorWithPayload<number, string>,
+) => {
+  const dispatch = useAppDispatch();
+  const duration = useAppSelector(selectDuration);
+  const durationInSeconds = useAppSelector(selectDurationInSeconds);
+  const timelineZoom = useAppSelector(selectTimelineZoom);
+  const displayDuration = useAppSelector(selectDisplayDuration);
+
+  const ref = useRef<HTMLDivElement>(null);
+  const { width = 1 } = useResizeObserver({ ref: ref as React.RefObject<HTMLDivElement> });
+  const scrollContainerRef = useRef<HTMLElement>(null);
+  const { width: scrollContainerWidth = 1 } = useResizeObserver({
+    ref: scrollContainerRef as React.RefObject<HTMLElement>,
+  });
+
+  const currentlyScrolling = useRef(false);
+  const zoomCenter = useRef(0);
+
+  const [scrollLeft, setScrollLeft] = useState(0);
+  const [visibleWidth, setVisibleWidth] = useState(0);
+
+  // Keep track of what point of the timeline should stay in view when the zoom level changes
+  const updateScroll = () => {
+    if (currentlyScrolling.current) {
+      currentlyScrolling.current = false;
+      return;
+    }
+    const scrollLeft = scrollContainerRef.current?.scrollLeft ?? 0;
+    const clientWidth = scrollContainerRef.current?.clientWidth ?? 0;
+    const centerPosition = scrollLeft + 0.5 * clientWidth;
+    const scrubberPosition = duration ? (currentlyAt / duration) * width : 0;
+    const scrubberVisible = scrollLeft <= scrubberPosition && scrubberPosition <= scrollLeft + clientWidth;
+
+    zoomCenter.current = (scrubberVisible ? scrubberPosition : centerPosition) / width;
+  };
+
+  const updateScrollMetrics = () => {
+    if (!scrollContainerRef.current) {
+      return;
+    }
+    const el = scrollContainerRef.current;
+    setScrollLeft(el.scrollLeft);
+    setVisibleWidth(el.clientWidth);
+  };
+
+  const displayPercentage = (durationInSeconds / displayDuration);
+  const zoomedWidth = scrollContainerWidth * displayPercentage;
+
+  // Make sure visibleWidth is set so canvas is drawn on first render
+  useLayoutEffect(() => {
+    updateScrollMetrics();
+  }, [width, duration]);
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(updateScroll, [currentlyAt, timelineZoom, width, scrollContainerWidth]);
+
+  // Keep the previously visible point of the timeline in view when the zoom level changes
+  useEffect(() => {
+    if (!scrollContainerRef.current) {
+      return;
+    }
+    const clientWidth = scrollContainerRef.current.clientWidth ?? 0;
+    const left = zoomCenter.current * displayPercentage * clientWidth - 0.5 * clientWidth;
+
+    currentlyScrolling.current = true;
+    scrollContainerRef.current.scrollLeft = left;
+  }, [displayPercentage]);
+
+  // Update the current time based on the position clicked on the timeline
+  const setCurrentlyAtToClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const offsetX = e.clientX - rect.left;
+    dispatch(setClickTriggered(true));
+    dispatch(setCurrentlyAt((offsetX / width) * (duration)));
+  };
+
+  // Scroll the scroll container by its width one time
+  // To be used when the scrubber moves out of sight while playing the video.
+  const scrollByOwnWidth = () => {
+    if (scrollContainerRef.current) {
+      scrollContainerRef.current.scrollLeft = scrollContainerRef.current?.scrollLeft + scrollContainerWidth;
+      updateScroll();
+    }
+  };
+
+  return {
+    duration, ref, width, scrollContainerRef, scrollContainerWidth,
+    scrollLeft, visibleWidth, zoomedWidth,
+    updateScrollMetrics, updateScroll, setCurrentlyAtToClick, scrollByOwnWidth,
+  };
+};
+
+/**
  * A container for visualizing the cutting of the video, as well as for controlling
  * the current position in the video
  * Its width corresponds to the duration of the video
@@ -74,100 +174,23 @@ const Timeline: React.FC<{
 
   // Init redux variables
   const currentlyAt = useAppSelector(selectCurrentlyAt);
-  const dispatch = useAppDispatch();
-  const duration = useAppSelector(selectDuration);
-  const durationInSeconds = useAppSelector(selectDurationInSeconds);
-  const timelineZoom = useAppSelector(selectTimelineZoom);
-  const displayDuration = useAppSelector(selectDisplayDuration);
 
   const scrubberRef = useRef<HTMLDivElement | null>(null);
-  const ref = useRef<HTMLDivElement>(null);
-  const { width = 1 } = useResizeObserver({ ref: ref as React.RefObject<HTMLDivElement> });
-  const scrollContainerRef = useRef<HTMLElement>(null);
-  const { width: scrollContainerWidth = 1 } = useResizeObserver({
-    ref: scrollContainerRef as React.RefObject<HTMLElement>,
-  });
-
-  const currentlyScrolling = useRef(false);
-  const zoomCenter = useRef(0);
+  const {
+    duration, ref, width, scrollContainerRef, scrollContainerWidth,
+    scrollLeft, visibleWidth, zoomedWidth,
+    updateScrollMetrics, updateScroll, setCurrentlyAtToClick, scrollByOwnWidth,
+  } = useZoomableTimeline(currentlyAt, setClickTriggered, setCurrentlyAt);
 
   // Vars for timelineStamps
   const timelineStampsHeight = 20;
   const waveformHeight = timelineHeight - timelineStampsHeight;
-  const [scrollLeft, setScrollLeft] = useState(0);
-  const [visibleWidth, setVisibleWidth] = useState(0);
-
-  const updateScroll = () => {
-    if (currentlyScrolling.current) {
-      currentlyScrolling.current = false;
-      return;
-    }
-    const scrollLeft = scrollContainerRef.current?.scrollLeft ?? 0;
-    const clientWidth = scrollContainerRef.current?.clientWidth ?? 0;
-    const centerPosition = scrollLeft + 0.5 * clientWidth;
-    const scrubberPosition = duration ? (currentlyAt / duration) * width : 0;
-    const scrubberVisible = scrollLeft <= scrubberPosition && scrubberPosition <= scrollLeft + clientWidth;
-
-    zoomCenter.current = (scrubberVisible ? scrubberPosition : centerPosition) / width;
-
-  };
-
-  const updateScrollMetrics = () => {
-    if (!scrollContainerRef.current) {
-      return;
-    }
-    const el = scrollContainerRef.current;
-    setScrollLeft(el.scrollLeft);
-    setVisibleWidth(el.clientWidth);
-  };
-
-  const displayPercentage = (durationInSeconds / displayDuration);
-  const getWaveformWidth = (baseWidth: number) => {
-    return baseWidth * displayPercentage;
-  };
-  const zoomedWidth = getWaveformWidth(scrollContainerWidth);
-
-  // Make sure visibleWidth is set so canvas is drawn on first render
-  useLayoutEffect(() => {
-    updateScrollMetrics();
-  }, [width, duration]);
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(updateScroll, [currentlyAt, timelineZoom, width, scrollContainerWidth]);
-
-  useEffect(() => {
-    if (!scrollContainerRef.current) {
-      return;
-    }
-    const clientWidth = scrollContainerRef.current.clientWidth ?? 0;
-    const left = zoomCenter.current * displayPercentage * clientWidth - 0.5 * clientWidth;
-
-    currentlyScrolling.current = true;
-    scrollContainerRef.current.scrollLeft = left;
-  }, [displayPercentage]);
 
   const timelineStyle = css({
     position: "relative",     // Need to set position for Draggable bounds to work
     height: timelineHeight + "px",
     width: `${zoomedWidth}px`,    // Width modified by zoom
   });
-
-  // Update the current time based on the position clicked on the timeline
-  const setCurrentlyAtToClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const offsetX = e.clientX - rect.left;
-    dispatch(setClickTriggered(true));
-    dispatch(setCurrentlyAt((offsetX / width) * (duration)));
-  };
-
-  // Scroll the scroll container by its width one time
-  // To be used when the scrubber moves out of sight while playing the video.
-  const scrollByOwnWidth = () => {
-    if (scrollContainerRef.current) {
-      scrollContainerRef.current.scrollLeft = scrollContainerRef.current?.scrollLeft + scrollContainerWidth;
-      updateScroll();
-    }
-  };
 
   return (
     <CuttingActionsContextMenu>


### PR DESCRIPTION
Makes the timeline component in the subtitle view look and behave more like in other views, e.g. the chapter view. So no more fixed zoom level, and no more scrubber always sitting in the middle. This should make it a bit more intuitive for users to use the subtitles view.

Also added zooming to the thumbnail generation view while I was already at it, so every timeline in the editor is now properly zoomable.

### How to test this

Can be tested as is, focus on the subtitle view.

### AI Usage

Claude Sonnet 5 was used to help with this PR.

